### PR TITLE
Remove bit-banding header from the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ target_sources(${PROJECT_NAME} INTERFACE
     "${CMAKE_CURRENT_SOURCE_DIR}/cortexm0plus/special_regs.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/cortexm0plus/systick.hpp"
     # Cortex-M3 headers
-    "${CMAKE_CURRENT_SOURCE_DIR}/cortexm3/bitband.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/cortexm3/exceptions.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/cortexm3/mpu.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/cortexm3/nvic.hpp"


### PR DESCRIPTION
## Summary
This PR removes the bit-banding header that was incorrectly added to the library.

## Reason for Removal
After further review, the bit-banding header doesn't belong in this library because:
- It doesn't provide access to any actual hardware resources
- It's just address arithmetic that users can implement themselves
- The library's philosophy is to only include hardware abstraction interfaces, not convenience functions

## Changes
- ✅ Removed `cortexm3/bitband.hpp` reference from CMakeLists.txt
- ⚠️ **Note**: The actual `cortexm3/bitband.hpp` file still needs to be deleted manually or through the GitHub web interface, as the GitHub API doesn't provide a straightforward way to delete files programmatically through the current MCP implementation.

## Next Steps
After merging this PR, please manually delete the `cortexm3/bitband.hpp` file from the repository.