### PR TITLE
Add missing VTOR union definition for Cortex-M0+

### DIFF
--- a/cortexm0plus/scb.hpp
+++ b/cortexm0plus/scb.hpp
@@ -69,6 +69,23 @@ namespace CortexM0Plus::Scb {
         }
     };
 
+    //! vector table offset register
+    union Vtor {
+        struct Bits {
+            uint32_t reserved: 7; //!< reserved, must be zero
+            uint32_t table_offset: 25; //!< vector table offset from memory address 0x00000000
+        } bits;
+
+        uint32_t value = 0;
+
+        Vtor() = default;
+
+        Vtor(uint32_t new_value)
+        {
+            value = new_value;
+        }
+    };
+
     //! enables system reset
     union Aircr {
         static constexpr uint16_t VECT_KEY = 0x05FA; //!< magic number used for enabling writing to Aircr


### PR DESCRIPTION
## Description
This PR adds the missing VTOR (Vector Table Offset Register) union definition for the Cortex-M0+ implementation.

## Problem
The VTOR register field was already declared in the `Registers` struct at the correct offset, but the corresponding `Vtor` union definition was missing. This made it impossible to properly manipulate the VTOR register using the structured approach that the library provides for other registers.

## Solution
Added the `Vtor` union definition with the correct bit layout for Cortex-M0+:
- **Bits [31:7]**: Vector table offset (25 bits) - must be 128-byte aligned
- **Bits [6:0]**: Reserved (7 bits) - read as zero

## Importance
VTOR is an important register that allows relocating the vector table, which is essential for:
- Bootloader implementations
- Dynamic vector table management
- Applications that need to move the vector table to RAM

## Testing
The change follows the same pattern as other register definitions in the library and matches the Cortex-M0+ architecture specification.