### PR TITLE
Add Cortex-M1 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,12 @@ target_sources(${PROJECT_NAME} INTERFACE
     "${CMAKE_CURRENT_SOURCE_DIR}/cortexm0/scb.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/cortexm0/special_regs.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/cortexm0/systick.hpp"
+    # Cortex-M1 headers
+    "${CMAKE_CURRENT_SOURCE_DIR}/cortexm1/exceptions.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cortexm1/nvic.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cortexm1/scb.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cortexm1/special_regs.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cortexm1/systick.hpp"
     # Cortex-M0+ headers
     "${CMAKE_CURRENT_SOURCE_DIR}/cortexm0plus/exceptions.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/cortexm0plus/mpu.hpp"

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ CMSIS-like C++ library for ARM Cortex-M microcontrollers
 
 - ARM Cortex-M0
 - ARM Cortex-M0+
+- ARM Cortex-M1
 - ARM Cortex-M3
 
 ## License
 
 This library is licensed under Apache License Version 2.0.  
 Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/ARMCortexM-CppLib>.  
-See the attached [LICENSE](./LICENCE) file for more info.
+See the attached [LICENCE](./LICENCE) file for more info.

--- a/cortexm1/exceptions.hpp
+++ b/cortexm1/exceptions.hpp
@@ -1,0 +1,55 @@
+/*
+    Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/ARMCortexM-CppLib>
+
+    Licensed under the Apache License, Version 2.0 (the "Licence");
+    you may not use this file except in compliance with the Licence.
+    You may obtain a copy of the Licence at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the Licence is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the Licence for the specific language governing permissions and
+    limitations under the Licence.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace CortexM1 {
+    static constexpr uint8_t NUM_OF_IRQS = 32;
+
+    enum class ExceptionNumber : uint8_t {
+        THREAD_MODE = 0,
+        RESET = 1,
+        NMI = 2,
+        HARD_FAULT = 3,
+        SV_CALL = 11,
+        PEND_SV = 14,
+        SYS_TICK = 15,
+        FIRST_IRQ = 16,
+        LAST_IRQ = FIRST_IRQ + NUM_OF_IRQS - 1
+    };
+
+    static inline void enableExceptions()
+    {
+        asm volatile("cpsie i" : : : "memory");
+        asm volatile("dsb" : : : "memory");
+        asm volatile("isb" : : : "memory");
+    }
+
+    static inline void disableExceptions()
+    {
+        asm volatile("cpsid i" : : : "memory");
+        asm volatile("dsb" : : : "memory");
+        asm volatile("isb" : : : "memory");
+    }
+
+    static inline bool isIrqNumber(ExceptionNumber exception)
+    {
+        return (static_cast<uint8_t>(exception) >= static_cast<uint8_t>(ExceptionNumber::FIRST_IRQ) &&
+            static_cast<uint8_t>(exception) <= static_cast<uint8_t>(ExceptionNumber::LAST_IRQ));
+    }
+}

--- a/cortexm1/nvic.hpp
+++ b/cortexm1/nvic.hpp
@@ -1,0 +1,91 @@
+/*
+    Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/ARMCortexM-CppLib>
+
+    Licensed under the Apache License, Version 2.0 (the "Licence");
+    you may not use this file except in compliance with the Licence.
+    You may obtain a copy of the Licence at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the Licence is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the Licence for the specific language governing permissions and
+    limitations under the Licence.
+*/
+
+#pragma once
+
+#include "utils.hpp"
+#include <cstdint>
+
+namespace CortexM1::Nvic {
+    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000E100);
+
+    struct Registers
+    {
+        volatile uint32_t iser[1]; //!< enables interrupts, and shows which interrupts are enabled
+        volatile uint32_t reserved0[31];
+        volatile uint32_t icer[1]; //!< disables interrupts, and shows which interrupts are enabled
+        volatile uint32_t reserved1[31];
+        volatile uint32_t ispr[1]; //!< forces interrupts into pending state, and shows which interrupts are pending
+        volatile uint32_t reserved2[31];
+        volatile uint32_t icpr[1]; //!< removes pending state from interrupts and shows which interrupts are pending
+        volatile uint32_t reserved3[31];
+        volatile uint32_t reserved4[64];
+        volatile uint8_t ipr[32]; //!< sets priorities of interrupts (8-bit registers)
+    };
+
+    static inline volatile Registers* registers()
+    {
+        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+    }
+
+    static inline bool isIrqEnabled(uint8_t irq_number)
+    {
+        return Utils::isBitSet(registers()->iser[0], irq_number);
+    }
+
+    static inline void enableIrq(uint8_t irq_number)
+    {
+        Utils::setBit(registers()->iser[0], irq_number);
+        asm volatile("DSB" : : : "memory");
+        asm volatile("ISB" : : : "memory");
+    }
+
+    static inline void disableIrq(uint8_t irq_number)
+    {
+        Utils::setBit(registers()->icer[0], irq_number);
+        asm volatile("DSB" : : : "memory");
+        asm volatile("ISB" : : : "memory");
+    }
+
+    static inline bool isIrqPending(uint8_t irq_number)
+    {
+        return Utils::isBitSet(registers()->ispr[0], irq_number);
+    }
+
+    static inline void setPendingIrq(uint8_t irq_number)
+    {
+        Utils::setBit(registers()->ispr[0], irq_number);
+        asm volatile("DSB" : : : "memory");
+        asm volatile("ISB" : : : "memory");
+    }
+
+    static inline void clearPendingIrq(uint8_t irq_number)
+    {
+        Utils::setBit(registers()->icpr[0], irq_number);
+        asm volatile("DSB" : : : "memory");
+        asm volatile("ISB" : : : "memory");
+    }
+
+    static inline void setIrqPriority(uint8_t irq_number, uint8_t irq_priority)
+    {
+        registers()->ipr[irq_number] = irq_priority;
+    }
+
+    static inline uint8_t getIrqPriority(uint8_t irq_number)
+    {
+        return registers()->ipr[irq_number];
+    }
+}

--- a/cortexm1/scb.hpp
+++ b/cortexm1/scb.hpp
@@ -1,0 +1,201 @@
+/*
+    Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/ARMCortexM-CppLib>
+
+    Licensed under the Apache License, Version 2.0 (the "Licence");
+    you may not use this file except in compliance with the Licence.
+    You may obtain a copy of the Licence at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the Licence is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the Licence for the specific language governing permissions and
+    limitations under the Licence.
+*/
+
+#pragma once
+
+#include "utils.hpp"
+#include <cstdint>
+
+namespace CortexM1::Scb {
+    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000ED00);
+
+    enum class SleepMode : uint8_t {
+        NORMAL = 0,
+        DEEP = 1
+    };
+
+    enum class VectorTableBase : uint8_t {
+        CODE = 0,
+        SRAM = 1
+    };
+
+    struct Registers
+    {
+        volatile const uint32_t cpuid; //!< Contains the processor part number, version, and implementation information
+        volatile uint32_t icsr; //!< Provides system exception numbers and states
+        volatile uint32_t reserved0;
+        volatile uint32_t aircr; //!< Application interrupt and reset control
+        volatile uint32_t scr; //!< System control
+        volatile uint32_t ccr; //!< Configuration and control
+        volatile uint32_t reserved1;
+        volatile uint32_t shpr2; //!< System handler priority register 2
+        volatile uint32_t shpr3; //!< System handler priority register 3
+    };
+
+    static inline volatile Registers* registers()
+    {
+        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+    }
+
+    // CPUID register functions
+    static inline uint32_t getCpuId()
+    {
+        return registers()->cpuid;
+    }
+
+    // ICSR register functions
+    static inline bool isVectorActive()
+    {
+        return (registers()->icsr & 0x1FF) != 0;
+    }
+
+    static inline uint8_t getActiveVectorNumber()
+    {
+        return registers()->icsr & 0x1FF;
+    }
+
+    static inline bool isVectorPending()
+    {
+        return Utils::isBitSet(registers()->icsr, 22);
+    }
+
+    static inline uint8_t getPendingVectorNumber()
+    {
+        return (registers()->icsr >> 12) & 0x1FF;
+    }
+
+    static inline void setPendStClr()
+    {
+        Utils::setBit(registers()->icsr, 25);
+    }
+
+    static inline void setPendStSet()
+    {
+        Utils::setBit(registers()->icsr, 26);
+    }
+
+    static inline void setPendSvClr()
+    {
+        Utils::setBit(registers()->icsr, 27);
+    }
+
+    static inline void setPendSvSet()
+    {
+        Utils::setBit(registers()->icsr, 28);
+    }
+
+    static inline bool isNmiPending()
+    {
+        return Utils::isBitSet(registers()->icsr, 31);
+    }
+
+    static inline void setNmiPending()
+    {
+        Utils::setBit(registers()->icsr, 31);
+    }
+
+    // AIRCR register functions
+    static inline void requestSystemReset()
+    {
+        asm volatile("DSB" : : : "memory");
+        registers()->aircr = 0x05FA0004;
+        asm volatile("DSB" : : : "memory");
+        while (true) { asm volatile("NOP"); }
+    }
+
+    static inline bool isLittleEndian()
+    {
+        return !Utils::isBitSet(registers()->aircr, 15);
+    }
+
+    // SCR register functions
+    static inline void setSleepMode(SleepMode mode)
+    {
+        if (mode == SleepMode::DEEP) {
+            Utils::setBit(registers()->scr, 2);
+        } else {
+            Utils::clearBit(registers()->scr, 2);
+        }
+    }
+
+    static inline void setSleepOnExit(bool enable)
+    {
+        if (enable) {
+            Utils::setBit(registers()->scr, 1);
+        } else {
+            Utils::clearBit(registers()->scr, 1);
+        }
+    }
+
+    static inline void setEventOnPending(bool enable)
+    {
+        if (enable) {
+            Utils::setBit(registers()->scr, 4);
+        } else {
+            Utils::clearBit(registers()->scr, 4);
+        }
+    }
+
+    // CCR register functions
+    static inline void setUnalignedAccessTrap(bool enable)
+    {
+        if (enable) {
+            Utils::setBit(registers()->ccr, 3);
+        } else {
+            Utils::clearBit(registers()->ccr, 3);
+        }
+    }
+
+    static inline void setStackAlign8(bool enable)
+    {
+        if (enable) {
+            Utils::setBit(registers()->ccr, 9);
+        } else {
+            Utils::clearBit(registers()->ccr, 9);
+        }
+    }
+
+    // SHPR register functions
+    static inline void setSvCallPriority(uint8_t priority)
+    {
+        registers()->shpr2 = (registers()->shpr2 & 0x00FFFFFF) | (static_cast<uint32_t>(priority) << 24);
+    }
+
+    static inline uint8_t getSvCallPriority()
+    {
+        return (registers()->shpr2 >> 24) & 0xFF;
+    }
+
+    static inline void setPendSvPriority(uint8_t priority)
+    {
+        registers()->shpr3 = (registers()->shpr3 & 0xFFFF00FF) | (static_cast<uint32_t>(priority) << 16);
+    }
+
+    static inline uint8_t getPendSvPriority()
+    {
+        return (registers()->shpr3 >> 16) & 0xFF;
+    }
+
+    static inline void setSysTickPriority(uint8_t priority)
+    {
+        registers()->shpr3 = (registers()->shpr3 & 0x00FFFFFF) | (static_cast<uint32_t>(priority) << 24);
+    }
+
+    static inline uint8_t getSysTickPriority()
+    {
+        return (registers()->shpr3 >> 24) & 0xFF;
+    }
+}

--- a/cortexm1/special_regs.hpp
+++ b/cortexm1/special_regs.hpp
@@ -1,0 +1,189 @@
+/*
+    Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/ARMCortexM-CppLib>
+
+    Licensed under the Apache License, Version 2.0 (the "Licence");
+    you may not use this file except in compliance with the Licence.
+    You may obtain a copy of the Licence at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the Licence is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the Licence for the specific language governing permissions and
+    limitations under the Licence.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace CortexM1::SpecialRegs {
+    enum class Register : uint8_t {
+        APSR = 0,
+        IPSR = 5,
+        EPSR = 6,
+        IEPSR = 7,
+        MSP = 8,
+        PSP = 9,
+        PRIMASK = 16,
+        CONTROL = 20
+    };
+
+    enum class ControlSpSel : uint8_t {
+        MSP = 0,
+        PSP = 1
+    };
+
+    static inline uint32_t getApsr()
+    {
+        uint32_t result;
+        asm volatile("MRS %0, APSR" : "=r" (result));
+        return result;
+    }
+
+    static inline void setApsr(uint32_t value)
+    {
+        asm volatile("MSR APSR_nzcvq, %0" : : "r" (value) : "memory");
+    }
+
+    static inline uint32_t getIpsr()
+    {
+        uint32_t result;
+        asm volatile("MRS %0, IPSR" : "=r" (result));
+        return result;
+    }
+
+    static inline uint32_t getEpsr()
+    {
+        uint32_t result;
+        asm volatile("MRS %0, EPSR" : "=r" (result));
+        return result;
+    }
+
+    static inline uint32_t getMsp()
+    {
+        uint32_t result;
+        asm volatile("MRS %0, MSP" : "=r" (result));
+        return result;
+    }
+
+    static inline void setMsp(uint32_t value)
+    {
+        asm volatile("MSR MSP, %0" : : "r" (value) : "memory");
+    }
+
+    static inline uint32_t getPsp()
+    {
+        uint32_t result;
+        asm volatile("MRS %0, PSP" : "=r" (result));
+        return result;
+    }
+
+    static inline void setPsp(uint32_t value)
+    {
+        asm volatile("MSR PSP, %0" : : "r" (value) : "memory");
+    }
+
+    static inline uint32_t getPrimask()
+    {
+        uint32_t result;
+        asm volatile("MRS %0, PRIMASK" : "=r" (result));
+        return result;
+    }
+
+    static inline void setPrimask(uint32_t value)
+    {
+        asm volatile("MSR PRIMASK, %0" : : "r" (value) : "memory");
+    }
+
+    static inline void enableInterrupts()
+    {
+        asm volatile("CPSIE I" : : : "memory");
+    }
+
+    static inline void disableInterrupts()
+    {
+        asm volatile("CPSID I" : : : "memory");
+    }
+
+    static inline uint32_t getControl()
+    {
+        uint32_t result;
+        asm volatile("MRS %0, CONTROL" : "=r" (result));
+        return result;
+    }
+
+    static inline void setControl(uint32_t value)
+    {
+        asm volatile("MSR CONTROL, %0" : : "r" (value) : "memory");
+        asm volatile("ISB" : : : "memory");
+    }
+
+    static inline ControlSpSel getStackPointerSelect()
+    {
+        return static_cast<ControlSpSel>((getControl() >> 1) & 0x1);
+    }
+
+    static inline void setStackPointerSelect(ControlSpSel sp_sel)
+    {
+        uint32_t control = getControl();
+        control = (control & ~0x2) | (static_cast<uint32_t>(sp_sel) << 1);
+        setControl(control);
+    }
+
+    static inline uint32_t getRegister(Register reg)
+    {
+        uint32_t result;
+        switch (reg) {
+            case Register::APSR:
+                result = getApsr();
+                break;
+            case Register::IPSR:
+                result = getIpsr();
+                break;
+            case Register::EPSR:
+                result = getEpsr();
+                break;
+            case Register::MSP:
+                result = getMsp();
+                break;
+            case Register::PSP:
+                result = getPsp();
+                break;
+            case Register::PRIMASK:
+                result = getPrimask();
+                break;
+            case Register::CONTROL:
+                result = getControl();
+                break;
+            default:
+                result = 0;
+                break;
+        }
+        return result;
+    }
+
+    static inline void setRegister(Register reg, uint32_t value)
+    {
+        switch (reg) {
+            case Register::APSR:
+                setApsr(value);
+                break;
+            case Register::MSP:
+                setMsp(value);
+                break;
+            case Register::PSP:
+                setPsp(value);
+                break;
+            case Register::PRIMASK:
+                setPrimask(value);
+                break;
+            case Register::CONTROL:
+                setControl(value);
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/cortexm1/systick.hpp
+++ b/cortexm1/systick.hpp
@@ -1,0 +1,126 @@
+/*
+    Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/ARMCortexM-CppLib>
+
+    Licensed under the Apache License, Version 2.0 (the "Licence");
+    you may not use this file except in compliance with the Licence.
+    You may obtain a copy of the Licence at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the Licence is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the Licence for the specific language governing permissions and
+    limitations under the Licence.
+*/
+
+#pragma once
+
+#include "utils.hpp"
+#include <cstdint>
+
+namespace CortexM1::Systick {
+    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000E010);
+
+    enum class ClockSource : uint8_t {
+        EXTERNAL = 0,
+        PROCESSOR = 1
+    };
+
+    struct Registers
+    {
+        volatile uint32_t csr; //!< Control and status register
+        volatile uint32_t rvr; //!< Reload value register
+        volatile uint32_t cvr; //!< Current value register
+        volatile const uint32_t calib; //!< Calibration value register
+    };
+
+    static inline volatile Registers* registers()
+    {
+        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+    }
+
+    static inline void enable()
+    {
+        Utils::setBit(registers()->csr, 0);
+    }
+
+    static inline void disable()
+    {
+        Utils::clearBit(registers()->csr, 0);
+    }
+
+    static inline bool isEnabled()
+    {
+        return Utils::isBitSet(registers()->csr, 0);
+    }
+
+    static inline void enableInterrupt()
+    {
+        Utils::setBit(registers()->csr, 1);
+    }
+
+    static inline void disableInterrupt()
+    {
+        Utils::clearBit(registers()->csr, 1);
+    }
+
+    static inline bool isInterruptEnabled()
+    {
+        return Utils::isBitSet(registers()->csr, 1);
+    }
+
+    static inline void setClockSource(ClockSource source)
+    {
+        if (source == ClockSource::PROCESSOR) {
+            Utils::setBit(registers()->csr, 2);
+        } else {
+            Utils::clearBit(registers()->csr, 2);
+        }
+    }
+
+    static inline ClockSource getClockSource()
+    {
+        return static_cast<ClockSource>(Utils::isBitSet(registers()->csr, 2) ? 1 : 0);
+    }
+
+    static inline bool hasCountedToZero()
+    {
+        return Utils::isBitSet(registers()->csr, 16);
+    }
+
+    static inline void setReloadValue(uint32_t value)
+    {
+        registers()->rvr = value & 0x00FFFFFF;
+    }
+
+    static inline uint32_t getReloadValue()
+    {
+        return registers()->rvr & 0x00FFFFFF;
+    }
+
+    static inline void setCurrentValue(uint32_t value)
+    {
+        registers()->cvr = value;
+    }
+
+    static inline uint32_t getCurrentValue()
+    {
+        return registers()->cvr & 0x00FFFFFF;
+    }
+
+    static inline uint32_t getCalibrationValue()
+    {
+        return registers()->calib & 0x00FFFFFF;
+    }
+
+    static inline bool isNoRef()
+    {
+        return Utils::isBitSet(registers()->calib, 31);
+    }
+
+    static inline bool isSkew()
+    {
+        return Utils::isBitSet(registers()->calib, 30);
+    }
+}


### PR DESCRIPTION
## Description

This PR adds support for ARM Cortex-M1 microcontrollers to the ARMCortexM-CppLib library.

## Changes

- Added complete Cortex-M1 support with all core components:
  - Exception handling (`cortexm1/exceptions.hpp`)
  - NVIC (Nested Vectored Interrupt Controller) (`cortexm1/nvic.hpp`)
  - SCB (System Control Block) (`cortexm1/scb.hpp`)
  - Special registers access (`cortexm1/special_regs.hpp`)
  - SysTick timer (`cortexm1/systick.hpp`)
- Updated `CMakeLists.txt` to include the new M1 headers
- Updated `README.md` to list M1 as a supported architecture

## Implementation Details

The Cortex-M1 implementation follows the same design patterns and coding style as the existing M0, M0+, and M3 implementations:
- Header-only library with inline functions
- Zero-overhead abstractions using C++17
- Proper memory barriers (DSB, ISB) where needed
- Use of enum classes for type safety
- Consistent namespace structure (`CortexM1::`)

## Architecture Notes

Cortex-M1 is based on the ARMv6-M architecture (similar to M0) and is designed specifically for FPGA implementations. Key characteristics:
- Supports up to 32 external interrupts
- No MPU (Memory Protection Unit)
- Similar exception model to Cortex-M0
- 2-stage pipeline architecture

## Testing

The implementation follows the established patterns from the existing architectures and maintains API consistency across all supported Cortex-M variants.