### PR TITLE
Add ARM Cortex-M0 intrinsic functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,34 @@
 
 CMSIS-like C++ library for ARM Cortex-M microcontrollers
 
+## Features
+
+### Cortex-M0 Support
+
+The library provides the following components for ARM Cortex-M0:
+
+- **Memory Barriers** (`barriers.hpp`): DSB, ISB, DMB, and compiler barriers
+- **Exception Handling** (`exceptions.hpp`): Enable/disable exceptions, exception numbers
+- **NVIC** (`nvic.hpp`): Nested Vectored Interrupt Controller functions
+- **SCB** (`scb.hpp`): System Control Block register access
+- **Special Registers** (`special_regs.hpp`): Access to PSR, PRIMASK, CONTROL, MSP, PSP registers
+- **SysTick** (`systick.hpp`): System timer functions
+- **Intrinsics** (`intrinsics.hpp`): CPU intrinsic functions including:
+  - `SendEvent()` - SEV instruction
+  - `WaitForEvent()` - WFE instruction  
+  - `WaitForInterrupt()` - WFI instruction
+  - `Nop()` - NOP instruction
+  - `Yield()` - YIELD instruction
+  - `Breakpoint(value)` - BKPT instruction
+  - `ReverseBytes(value)` - REV instruction
+  - `ReverseBytes16(value)` - REV16 instruction
+  - `ReverseBytesSignedHalfword(value)` - REVSH instruction
+  - `CountLeadingZeros(value)` - CLZ instruction (if available)
+  - `UnsignedSaturate(value, bits)` - Software implementation of USAT
+  - `SignedSaturate(value, bits)` - Software implementation of SSAT
+
 ## License
 
-This library is licensed under Apache Licence Version 2.0.  \
-Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/ARMCortexM-CppLib>.  \
+This library is licensed under Apache License Version 2.0.  
+Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/ARMCortexM-CppLib>.  
 See the attached [LICENCE](./LICENCE) file for more info.

--- a/cortexm0/examples/intrinsics_example.cpp
+++ b/cortexm0/examples/intrinsics_example.cpp
@@ -1,0 +1,119 @@
+/*
+    Example usage of ARM Cortex-M0 intrinsic functions
+    
+    Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/ARMCortexM-CppLib>
+    Licensed under the Apache License, Version 2.0
+*/
+
+#include "cortexm0/intrinsics.hpp"
+#include "cortexm0/exceptions.hpp"
+#include <cstdint>
+
+// Example 1: Using WFI for low-power idle
+void low_power_idle()
+{
+    // Disable interrupts temporarily
+    CortexM0::disableExceptions();
+    
+    // Configure any wake-up sources here
+    // ...
+    
+    // Re-enable interrupts
+    CortexM0::enableExceptions();
+    
+    // Wait for interrupt - CPU will sleep until an interrupt occurs
+    CortexM0::WaitForInterrupt();
+}
+
+// Example 2: Using SEV/WFE for simple synchronization
+volatile bool event_flag = false;
+
+void producer_task()
+{
+    // Do some work
+    // ...
+    
+    // Signal that work is complete
+    event_flag = true;
+    CortexM0::SendEvent();
+}
+
+void consumer_task()
+{
+    // Wait for producer to complete
+    while (!event_flag) {
+        CortexM0::WaitForEvent();
+    }
+    
+    // Process the data
+    // ...
+    
+    event_flag = false;
+}
+
+// Example 3: Using byte reversal for endianness conversion
+uint32_t convert_endianness(uint32_t value)
+{
+    // Convert between big-endian and little-endian
+    return CortexM0::ReverseBytes(value);
+}
+
+// Example 4: Network byte order conversion
+uint16_t htons(uint16_t host_short)
+{
+    // Host to network short (16-bit)
+    uint32_t result = CortexM0::ReverseBytes16(host_short);
+    return static_cast<uint16_t>(result);
+}
+
+// Example 5: Saturating arithmetic for signal processing
+int16_t saturate_to_int16(int32_t value)
+{
+    // Saturate 32-bit value to 16-bit range
+    return static_cast<int16_t>(CortexM0::SignedSaturate(value, 16));
+}
+
+// Example 6: Debug breakpoint
+void debug_assert(bool condition)
+{
+    if (!condition) {
+        // Trigger debugger with specific code
+        CortexM0::Breakpoint(0x42);
+    }
+}
+
+// Example 7: Precise timing delays
+void delay_cycles(uint32_t cycles)
+{
+    // Each iteration is approximately 4 cycles
+    cycles = cycles / 4;
+    
+    for (uint32_t i = 0; i < cycles; i++) {
+        CortexM0::Nop();
+    }
+}
+
+// Example 8: Cooperative multitasking hint
+void background_task()
+{
+    while (true) {
+        // Do some non-critical work
+        // ...
+        
+        // Hint to scheduler that we can be preempted
+        CortexM0::Yield();
+    }
+}
+
+// Example 9: Finding highest bit set
+uint32_t find_highest_bit(uint32_t value)
+{
+    if (value == 0) {
+        return 0;
+    }
+    
+    // CLZ returns number of leading zeros
+    // So 31 - CLZ gives the position of the highest bit set
+    // Note: CLZ may not be available on all Cortex-M0 devices
+    return 31 - CortexM0::CountLeadingZeros(value);
+}

--- a/cortexm0/intrinsics.hpp
+++ b/cortexm0/intrinsics.hpp
@@ -1,0 +1,153 @@
+/*
+    Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/ARMCortexM-CppLib>
+
+    Licensed under the Apache License, Version 2.0 (the "Licence");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace CortexM0 {
+    //! Send Event hint instruction
+    //! Causes an event to be signaled to all processors within a multiprocessor system
+    static inline void SendEvent()
+    {
+        asm volatile("sev" : : : "memory");
+    }
+
+    //! Wait For Event hint instruction
+    //! If the event register is clear, the processor suspends execution until an event occurs
+    static inline void WaitForEvent()
+    {
+        asm volatile("wfe" : : : "memory");
+    }
+
+    //! Wait For Interrupt hint instruction
+    //! Suspends execution until an interrupt or debug event occurs
+    static inline void WaitForInterrupt()
+    {
+        asm volatile("wfi" : : : "memory");
+    }
+
+    //! No Operation instruction
+    //! Does nothing - can be used for timing or alignment purposes
+    static inline void Nop()
+    {
+        asm volatile("nop");
+    }
+
+    //! Yield hint instruction
+    //! Indicates that the current thread is performing a task that can be swapped out
+    static inline void Yield()
+    {
+        asm volatile("yield" : : : "memory");
+    }
+
+    //! Breakpoint instruction
+    //! Causes the processor to enter Debug state if halting debug is enabled
+    //! @param value Immediate value (0-255) that can be used by debugger
+    static inline void Breakpoint(uint8_t value = 0)
+    {
+        asm volatile("bkpt %0" : : "i" (value));
+    }
+
+    //! Reverse byte order in a word
+    //! @param value Input value
+    //! @return Value with bytes reversed (e.g., 0x12345678 -> 0x78563412)
+    static inline uint32_t ReverseBytes(uint32_t value)
+    {
+        uint32_t result;
+        asm volatile("rev %0, %1" : "=r" (result) : "r" (value));
+        return result;
+    }
+
+    //! Reverse byte order in each halfword
+    //! @param value Input value
+    //! @return Value with bytes reversed in each 16-bit halfword
+    static inline uint32_t ReverseBytes16(uint32_t value)
+    {
+        uint32_t result;
+        asm volatile("rev16 %0, %1" : "=r" (result) : "r" (value));
+        return result;
+    }
+
+    //! Reverse byte order in bottom halfword and sign extend
+    //! @param value Input value (uses lower 16 bits)
+    //! @return Sign-extended value with bytes reversed in the halfword
+    static inline int32_t ReverseBytesSignedHalfword(int32_t value)
+    {
+        int32_t result;
+        asm volatile("revsh %0, %1" : "=r" (result) : "r" (value));
+        return result;
+    }
+
+    //! Count leading zeros
+    //! Note: CLZ is optional in ARMv6-M (Cortex-M0/M0+). This function will only work
+    //! if your specific microcontroller includes the CLZ instruction.
+    //! @param value Input value
+    //! @return Number of leading zero bits (0-32)
+    static inline uint32_t CountLeadingZeros(uint32_t value)
+    {
+        uint32_t result;
+        asm volatile("clz %0, %1" : "=r" (result) : "r" (value));
+        return result;
+    }
+
+    //! Unsigned saturate
+    //! Saturates a signed value to an unsigned value with specified bit width
+    //! Note: USAT is NOT available on Cortex-M0. This is a software implementation.
+    //! @param value Signed input value to saturate
+    //! @param sat_bits Number of bits for saturation (1-32)
+    //! @return Saturated unsigned value
+    static inline uint32_t UnsignedSaturate(int32_t value, uint32_t sat_bits)
+    {
+        if (sat_bits == 0 || sat_bits > 32) {
+            return 0;  // Invalid saturation bits
+        }
+        
+        const uint32_t max_val = (1ULL << sat_bits) - 1;
+        
+        if (value < 0) {
+            return 0;  // Saturate to minimum
+        } else if (static_cast<uint32_t>(value) > max_val) {
+            return max_val;  // Saturate to maximum
+        }
+        
+        return static_cast<uint32_t>(value);
+    }
+
+    //! Signed saturate
+    //! Saturates a value to a signed value with specified bit width
+    //! Note: SSAT is NOT available on Cortex-M0. This is a software implementation.
+    //! @param value Input value to saturate
+    //! @param sat_bits Number of bits for saturation (1-32)
+    //! @return Saturated signed value
+    static inline int32_t SignedSaturate(int32_t value, uint32_t sat_bits)
+    {
+        if (sat_bits == 0 || sat_bits > 32) {
+            return 0;  // Invalid saturation bits
+        }
+        
+        const int32_t max_val = (1LL << (sat_bits - 1)) - 1;
+        const int32_t min_val = -(1LL << (sat_bits - 1));
+        
+        if (value > max_val) {
+            return max_val;  // Saturate to maximum
+        } else if (value < min_val) {
+            return min_val;  // Saturate to minimum
+        }
+        
+        return value;
+    }
+}


### PR DESCRIPTION
## Description

This PR adds missing ARM Cortex-M0 intrinsic functions that are not typically emitted by the compiler but are essential for system programming and low-level optimization.

## Changes

### New file: `cortexm0/intrinsics.hpp`
Added intrinsic functions for the following ARM Cortex-M0 instructions:

- **Power Management**
  - `WaitForInterrupt()` - WFI instruction for low-power idle
  - `WaitForEvent()` - WFE instruction for event-based synchronization
  - `SendEvent()` - SEV instruction to signal events

- **Control Flow**
  - `Nop()` - NOP instruction for timing/alignment
  - `Yield()` - YIELD instruction for cooperative multitasking
  - `Breakpoint(value)` - BKPT instruction for debugging

- **Data Processing**
  - `ReverseBytes(value)` - REV instruction for endianness conversion
  - `ReverseBytes16(value)` - REV16 instruction for 16-bit byte reversal
  - `ReverseBytesSignedHalfword(value)` - REVSH instruction
  - `CountLeadingZeros(value)` - CLZ instruction (optional on M0)
  - `UnsignedSaturate(value, bits)` - Software implementation of USAT
  - `SignedSaturate(value, bits)` - Software implementation of SSAT

### Updated: `README.md`
- Added comprehensive documentation of all library features
- Listed all available intrinsic functions with descriptions

### New file: `cortexm0/examples/intrinsics_example.cpp`
- Practical examples demonstrating usage of each intrinsic function
- Use cases include:
  - Low-power idle modes
  - Event-based synchronization
  - Endianness conversion for networking
  - Saturating arithmetic for signal processing
  - Debug assertions
  - Precise timing delays
  - Cooperative multitasking

## Notes

- The CLZ instruction is optional in ARMv6-M architecture (Cortex-M0/M0+). The implementation includes a note about this.
- USAT and SSAT instructions are not available on Cortex-M0, so software implementations are provided for compatibility.
- All intrinsics use inline assembly with appropriate constraints and memory barriers where needed.

## Testing

The intrinsics follow the same pattern as existing functions in the library (barriers.hpp, special_regs.hpp) and use standard GCC inline assembly syntax compatible with arm-none-eabi-gcc.