### PR TITLE
Simplify VCPKG setup - Remove CMake/Ninja from artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build-multi
 build-single
+vcpkg_installed/
+.tools/

--- a/README.md
+++ b/README.md
@@ -10,8 +10,65 @@ CMSIS-like C++ library for ARM Cortex-M microcontrollers
 - ARM Cortex-M3 (WIP)
 - TODO...
 
+## Prerequisites
+
+- CMake 3.13 or higher
+- Ninja build system
+- VCPKG (with `VCPKG_ROOT` environment variable set)
+
+### Installing Prerequisites
+
+#### Ubuntu/Debian
+```bash
+sudo apt install cmake ninja-build
+```
+
+#### macOS
+```bash
+brew install cmake ninja
+```
+
+#### Windows
+```bash
+# Using chocolatey
+choco install cmake ninja
+
+# Or using scoop
+scoop install cmake ninja
+```
+
+## Building
+
+### First Time Setup
+The ARM toolchain will be automatically downloaded via VCPKG on first configuration:
+
+```bash
+# Download and activate ARM toolchain locally (stored in .tools/)
+vcpkg x-download-tools --x-artifacts-root=./.tools
+eval $(vcpkg x-activate --x-artifacts-root=./.tools)  # Linux/macOS
+# OR for Windows:
+# vcpkg x-activate --x-artifacts-root=.\.tools > activate_env.bat && call activate_env.bat
+```
+
+### Configure and Build
+
+```bash
+# Configure project (select desired preset)
+cmake --preset multi
+
+# Build
+cmake --build build-multi --config Debug
+```
+
+Available presets:
+- `multi` - Ninja Multi-Config generator
+- `single-debug` - Debug build
+- `single-release` - Release build
+- `single-minsizerel` - Minimum size release build
+- `single-relwithdebinfo` - Release with debug info
+
 ## License
 
 This library is licensed under the Apache Licence Version 2.0.  
 Copyright (C) 2025 Matej Gomboc <https://github.com/MatejGomboc/ARMCortexM-CppLib>.  
-See the attached [LICENCE](./LICENCE) file for more info.  
+See the attached [LICENCE](./LICENCE) file for more info.

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,8 +7,6 @@
         }
     ],
     "requires": {
-        "arm:compilers/arm/arm-none-eabi-gcc": "latest",
-        "arm:tools/kitware/cmake": "latest",
-        "arm:tools/ninja-build/ninja": "latest"
+        "arm:compilers/arm/arm-none-eabi-gcc": "latest"
     }
 }


### PR DESCRIPTION
## Summary

This PR simplifies the VCPKG setup by removing CMake and Ninja from the artifact requirements, keeping only the ARM toolchain managed by VCPKG. This eliminates the "chicken and egg" problem while keeping the build environment clean and self-contained.

## Changes

### 🔧 Modified Files
- **`vcpkg-configuration.json`**: Removed `cmake` and `ninja` from requirements, keeping only the ARM GCC toolchain
- **`.gitignore`**: Added `vcpkg_installed/` and `.tools/` directories  
- **`README.md`**: Added comprehensive build prerequisites and instructions

## Benefits

✅ **Simpler setup** - No circular dependency issues  
✅ **Clean separation** - Build tools (CMake/Ninja) as normal prerequisites, ARM toolchain via VCPKG  
✅ **Self-contained** - ARM toolchain downloads locally to project folder  
✅ **No global pollution** - Everything project-specific stays in the repo directory  
✅ **Cross-platform** - Works on Windows, Linux, and macOS  

## How to Build

After merging, developers will need:
1. CMake and Ninja installed (via system package manager)
2. VCPKG with `VCPKG_ROOT` environment variable set
3. Run the build commands as documented in the updated README

The ARM toolchain will be automatically downloaded and managed by VCPKG in the local `.tools/` directory on first use.