### PR TITLE
Add GitHub Actions CI for automated testing

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,78 @@
+# GitHub Actions CI for ARMCortexM-CppLib
+
+This directory contains the GitHub Actions workflow for continuous integration.
+
+## CI Workflow (`ci.yml`)
+
+The CI workflow automatically runs tests for the ARMCortexM-CppLib project whenever:
+- Code is pushed to the `main` branch
+- A pull request is opened targeting the `main` branch
+- The workflow is manually triggered via the GitHub Actions UI
+
+### Test Matrix
+
+The workflow uses a matrix strategy to test all combinations of:
+
+#### ARM Cortex-M Architectures:
+- **M0** (`arch: "0"`) - Cortex-M0
+- **M0+** (`arch: "0+"`) - Cortex-M0+
+- **M1** (`arch: "1"`) - Cortex-M1
+- **M3** (`arch: "3"`) - Cortex-M3
+
+#### Build Types:
+- **Debug** - Full debugging symbols, no optimization
+- **Release** - Optimized for performance
+- **MinSizeRel** - Optimized for size
+- **RelWithDebInfo** - Release with debug symbols
+
+This results in **16 total test configurations** (4 architectures × 4 build types).
+
+### Key Features
+
+- **Ninja Multi-Config Generator**: Uses the `multi` preset exclusively for CI builds
+- **Parallel Testing**: All configurations run in parallel for faster feedback
+- **Comprehensive Toolchain**: Installs ARM GCC toolchain, CMake, Ninja, and FileCheck
+- **Test Artifacts**: Uploads test results and generated assembly files on failure
+- **Summary Job**: Provides a clear pass/fail status for the entire test suite
+
+### Tools Installed
+
+- `gcc-arm-none-eabi`: ARM cross-compiler
+- `binutils-arm-none-eabi`: ARM binary utilities (objdump, etc.)
+- `libnewlib-arm-none-eabi`: C library for embedded ARM
+- `cmake`: Build system generator
+- `ninja-build`: Fast build system
+- `llvm-17` (FileCheck): Test verification tool
+
+### Workflow Steps
+
+1. **Checkout**: Get the latest code
+2. **Install Dependencies**: Set up the build environment
+3. **Configure**: Run CMake with the multi preset and specific architecture
+4. **Build**: Compile using the appropriate multi-config preset
+5. **Test**: Run CTest for the specific configuration
+6. **Upload Artifacts**: Save test results if tests fail
+
+### Local Testing
+
+To replicate the CI environment locally:
+
+```bash
+# Configure for a specific architecture (e.g., Cortex-M3)
+cmake --preset=multi -DARM_CORTEX_M_ARCH="3" -DBUILD_ARM_CORTEX_M_TESTS=ON
+
+# Build for a specific configuration (e.g., Release)
+cmake --build --preset=multi-release
+
+# Run tests
+cd build-multi
+ctest -C Release --output-on-failure --verbose
+```
+
+### Troubleshooting
+
+If tests fail in CI:
+1. Check the test output in the workflow logs
+2. Download the uploaded artifacts for detailed assembly output
+3. Review the `LastTest.log` file for CTest details
+4. Ensure all required tools are properly installed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test (ARM Cortex-M${{ matrix.arch }}, ${{ matrix.build_type }})
+    runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ["0", "0+", "1", "3"]
+        build_type: [Debug, Release, MinSizeRel, RelWithDebInfo]
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            ninja-build \
+            gcc-arm-none-eabi \
+            binutils-arm-none-eabi \
+            libnewlib-arm-none-eabi
+      
+      - name: Install FileCheck
+        run: |
+          # Install LLVM tools including FileCheck
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
+          sudo apt-get update
+          sudo apt-get install -y llvm-17
+          sudo ln -sf /usr/bin/FileCheck-17 /usr/local/bin/FileCheck
+      
+      - name: Verify toolchain installation
+        run: |
+          arm-none-eabi-gcc --version
+          arm-none-eabi-objdump --version
+          cmake --version
+          ninja --version
+          FileCheck --version || echo "FileCheck version not available"
+      
+      - name: Configure CMake
+        run: |
+          cmake --preset=multi \
+            -DARM_CORTEX_M_ARCH="${{ matrix.arch }}" \
+            -DBUILD_ARM_CORTEX_M_TESTS=ON
+      
+      - name: Build
+        run: |
+          cmake --build --preset=multi-${{ contains(matrix.build_type, 'Rel') && 'release' || contains(matrix.build_type, 'Min') && 'minsizerel' || contains(matrix.build_type, 'Deb') && 'relwithdebinfo' || 'debug' }}
+      
+      - name: Run tests
+        working-directory: build-multi
+        run: |
+          ctest -C ${{ matrix.build_type }} --output-on-failure --verbose
+      
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-cortexm${{ matrix.arch }}-${{ matrix.build_type }}
+          path: |
+            build-multi/Testing/Temporary/LastTest.log
+            build-multi/**/*.asm
+
+  summary:
+    name: CI Summary
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.test.result }}" == "success" ]; then
+            echo "✅ All tests passed successfully!"
+          else
+            echo "❌ Some tests failed. Check the logs for details."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,19 @@ jobs:
       
       - name: Build
         run: |
-          cmake --build --preset=multi-${{ contains(matrix.build_type, 'Rel') && 'release' || contains(matrix.build_type, 'Min') && 'minsizerel' || contains(matrix.build_type, 'Deb') && 'relwithdebinfo' || 'debug' }}
+          # Map build_type to the correct preset name
+          if [ "${{ matrix.build_type }}" = "Debug" ]; then
+            BUILD_PRESET="multi-debug"
+          elif [ "${{ matrix.build_type }}" = "Release" ]; then
+            BUILD_PRESET="multi-release"
+          elif [ "${{ matrix.build_type }}" = "MinSizeRel" ]; then
+            BUILD_PRESET="multi-minsizerel"
+          elif [ "${{ matrix.build_type }}" = "RelWithDebInfo" ]; then
+            BUILD_PRESET="multi-relwithdebinfo"
+          fi
+          
+          echo "Building with preset: $BUILD_PRESET"
+          cmake --build --preset=$BUILD_PRESET
       
       - name: Run tests
         working-directory: build-multi


### PR DESCRIPTION
## Description

This PR adds GitHub Actions CI to automatically run tests for all supported ARM Cortex-M architectures and CMake build types whenever code is pushed or a pull request is created.

## Changes

- **`.github/workflows/ci.yml`**: Main CI workflow configuration
- **`.github/workflows/README.md`**: Documentation for the CI setup

## Test Matrix

The CI runs a comprehensive test matrix covering:
- **4 ARM Cortex-M architectures**: M0, M0+, M1, M3
- **4 CMake build types**: Debug, Release, MinSizeRel, RelWithDebInfo
- **Total**: 16 test configurations running in parallel

## Key Features

- ✅ Uses `ninja-multi` generator exclusively (as requested)
- ✅ Installs ARM GCC toolchain and all required dependencies
- ✅ Runs CTest for each configuration
- ✅ Uploads test artifacts on failure for debugging
- ✅ Provides clear pass/fail summary

## Workflow Triggers

The CI will run on:
- Push to `main` branch
- Pull requests targeting `main`
- Manual workflow dispatch

## Testing

Once merged, the CI will automatically start running on future commits. You can also manually trigger it from the Actions tab in GitHub.

## Local Testing

To test the same configurations locally:
```bash
# Example for Cortex-M3 Release build
cmake --preset=multi -DARM_CORTEX_M_ARCH="3" -DBUILD_ARM_CORTEX_M_TESTS=ON
cmake --build --preset=multi-release
cd build-multi && ctest -C Release --output-on-failure
```

---

Please review and let me know if you'd like any adjustments to the CI configuration!