### PR TITLE
fix(tests/m0plus): replace (void) casts with return values to prevent optimization

### DIFF
--- a/tests/m0/test_nvic.cpp
+++ b/tests/m0/test_nvic.cpp
@@ -1,14 +1,15 @@
 #include "armcortex/m0/nvic.hpp"
 
 // Test isIrqEnabled()
-extern "C" [[gnu::naked]] void test_is_irq_enabled() {
-    bool enabled = ArmCortex::Nvic::isIrqEnabled(5);
-    (void)enabled;
+extern "C" [[gnu::naked]] bool test_is_irq_enabled() {
+    return ArmCortex::Nvic::isIrqEnabled(5);
 }
 
 // CHECK-LABEL: <test_is_irq_enabled>:
-// CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #0]
+// CHECK-NEXT: ldr r3, [pc, #4]
+// CHECK-NEXT: ldr r0, [r3, #0]
+// CHECK-NEXT: lsls r0, r0, #26
+// CHECK-NEXT: lsrs r0, r0, #31
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-EMPTY:
 
@@ -67,27 +68,32 @@ extern "C" [[gnu::naked]] void test_disable_irq() {
 // CHECK-EMPTY:
 
 // Test isIrqPending()
-extern "C" [[gnu::naked]] void test_is_irq_pending() {
-    bool pending = ArmCortex::Nvic::isIrqPending(3);
-    (void)pending;
+extern "C" [[gnu::naked]] bool test_is_irq_pending() {
+    return ArmCortex::Nvic::isIrqPending(3);
 }
 
 // CHECK-LABEL: <test_is_irq_pending>:
 
-// DEBUG-CHECK-NEXT: ldr r2, [pc, #4]
+// DEBUG-CHECK-NEXT: ldr r2, [pc, #8]
 // DEBUG-CHECK-NEXT: movs r3, #128
 // DEBUG-CHECK-NEXT: lsls r3, r3, #1
-// DEBUG-CHECK-NEXT: ldr r3, [r2, r3]
+// DEBUG-CHECK-NEXT: ldr r0, [r2, r3]
+// DEBUG-CHECK-NEXT: lsls r0, r0, #28
+// DEBUG-CHECK-NEXT: lsrs r0, r0, #31
 // DEBUG-CHECK-NEXT: .word 0xe000e100
 
-// MINSIZE-CHECK-NEXT: ldr r3, [pc, #0]
-// MINSIZE-CHECK-NEXT: ldr r3, [r3, #4]
+// MINSIZE-CHECK-NEXT: ldr r3, [pc, #4]
+// MINSIZE-CHECK-NEXT: ldr r0, [r3, #4]
+// MINSIZE-CHECK-NEXT: lsls r0, r0, #28
+// MINSIZE-CHECK-NEXT: lsrs r0, r0, #31
 // MINSIZE-CHECK-NEXT: .word 0xe000e1fc
 
 // MAXSPEED-CHECK-NEXT: movs r3, #128
-// MAXSPEED-CHECK-NEXT: ldr r2, [pc, #4]
+// MAXSPEED-CHECK-NEXT: ldr r2, [pc, #8]
 // MAXSPEED-CHECK-NEXT: lsls r3, r3, #1
-// MAXSPEED-CHECK-NEXT: ldr r3, [r2, r3]
+// MAXSPEED-CHECK-NEXT: ldr r0, [r2, r3]
+// MAXSPEED-CHECK-NEXT: lsls r0, r0, #28
+// MAXSPEED-CHECK-NEXT: lsrs r0, r0, #31
 // MAXSPEED-CHECK-NEXT: .word 0xe000e100
 
 // CHECK-EMPTY:
@@ -157,16 +163,15 @@ extern "C" [[gnu::naked]] void test_clear_pending_irq() {
 // CHECK-EMPTY:
 
 // Test reading IPR (interrupt priority)
-extern "C" [[gnu::naked]] void test_read_ipr() {
-    uint8_t priority = ArmCortex::NVIC->IPR[5];
-    (void)priority;
+extern "C" [[gnu::naked]] uint8_t test_read_ipr() {
+    return ArmCortex::NVIC->IPR[5];
 }
 
 // CHECK-LABEL: <test_read_ipr>:
 // CHECK-NEXT: ldr r2, [pc, #4]
 // CHECK-NEXT: ldr r3, [pc, #8]
-// CHECK-NEXT: ldrb r3, [r2, r3]
-// CHECK-NEXT: nop
+// CHECK-NEXT: ldrb r0, [r2, r3]
+// CHECK-NEXT: uxtb r0, r0
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-NEXT: .word 0x00000305
 // CHECK-EMPTY:

--- a/tests/m0/test_scb.cpp
+++ b/tests/m0/test_scb.cpp
@@ -1,26 +1,24 @@
 #include "armcortex/m0/scb.hpp"
 
 // Test reading CPUID register
-extern "C" [[gnu::naked]] void test_read_cpuid() {
-    auto cpuid = ArmCortex::Scb::CPUID(ArmCortex::SCB->CPUID);
-    (void)cpuid;
+extern "C" [[gnu::naked]] auto test_read_cpuid() {
+    return ArmCortex::Scb::CPUID(ArmCortex::SCB->CPUID);
 }
 
 // CHECK-LABEL: <test_read_cpuid>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #0]
+// CHECK-NEXT: ldr r0, [r3, #0]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
 // Test reading ICSR register
-extern "C" [[gnu::naked]] void test_read_icsr() {
-    auto icsr = ArmCortex::Scb::ICSR(ArmCortex::SCB->ICSR);
-    (void)icsr;
+extern "C" [[gnu::naked]] auto test_read_icsr() {
+    return ArmCortex::Scb::ICSR(ArmCortex::SCB->ICSR);
 }
 
 // CHECK-LABEL: <test_read_icsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #4]
+// CHECK-NEXT: ldr r0, [r3, #4]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -56,14 +54,13 @@ extern "C" [[gnu::naked]] void test_write_icsr() {
 // Note: M0 does not have VTOR register (unlike M0Plus)
 
 // Test reading AIRCR register
-extern "C" [[gnu::naked]] void test_read_aircr() {
-    auto aircr = ArmCortex::Scb::AIRCR(ArmCortex::SCB->AIRCR);
-    (void)aircr;
+extern "C" [[gnu::naked]] auto test_read_aircr() {
+    return ArmCortex::Scb::AIRCR(ArmCortex::SCB->AIRCR);
 }
 
 // CHECK-LABEL: <test_read_aircr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #12]
+// CHECK-NEXT: ldr r0, [r3, #12]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -85,14 +82,13 @@ extern "C" [[gnu::naked]] void test_write_aircr() {
 // CHECK-EMPTY:
 
 // Test reading SCR register
-extern "C" [[gnu::naked]] void test_read_scr() {
-    auto scr = ArmCortex::Scb::SCR(ArmCortex::SCB->SCR);
-    (void)scr;
+extern "C" [[gnu::naked]] auto test_read_scr() {
+    return ArmCortex::Scb::SCR(ArmCortex::SCB->SCR);
 }
 
 // CHECK-LABEL: <test_read_scr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #16]
+// CHECK-NEXT: ldr r0, [r3, #16]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -126,26 +122,24 @@ extern "C" [[gnu::naked]] void test_write_scr() {
 // CHECK-EMPTY:
 
 // Test reading CCR register
-extern "C" [[gnu::naked]] void test_read_ccr() {
-    auto ccr = ArmCortex::Scb::CCR(ArmCortex::SCB->CCR);
-    (void)ccr;
+extern "C" [[gnu::naked]] auto test_read_ccr() {
+    return ArmCortex::Scb::CCR(ArmCortex::SCB->CCR);
 }
 
 // CHECK-LABEL: <test_read_ccr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #20]
+// CHECK-NEXT: ldr r0, [r3, #20]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
 // Test reading SHPR2 register
-extern "C" [[gnu::naked]] void test_read_shpr2() {
-    auto shpr2 = ArmCortex::Scb::SHPR2(ArmCortex::SCB->SHPR2);
-    (void)shpr2;
+extern "C" [[gnu::naked]] auto test_read_shpr2() {
+    return ArmCortex::Scb::SHPR2(ArmCortex::SCB->SHPR2);
 }
 
 // CHECK-LABEL: <test_read_shpr2>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #28]
+// CHECK-NEXT: ldr r0, [r3, #28]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -179,14 +173,13 @@ extern "C" [[gnu::naked]] void test_write_shpr2() {
 // CHECK-EMPTY:
 
 // Test reading SHPR3 register
-extern "C" [[gnu::naked]] void test_read_shpr3() {
-    auto shpr3 = ArmCortex::Scb::SHPR3(ArmCortex::SCB->SHPR3);
-    (void)shpr3;
+extern "C" [[gnu::naked]] auto test_read_shpr3() {
+    return ArmCortex::Scb::SHPR3(ArmCortex::SCB->SHPR3);
 }
 
 // CHECK-LABEL: <test_read_shpr3>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #32]
+// CHECK-NEXT: ldr r0, [r3, #32]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -208,14 +201,13 @@ extern "C" [[gnu::naked]] void test_write_shpr3() {
 // CHECK-EMPTY:
 
 // Test reading SHCSR register
-extern "C" [[gnu::naked]] void test_read_shcsr() {
-    auto shcsr = ArmCortex::Scb::SHCSR(ArmCortex::SCB->SHCSR);
-    (void)shcsr;
+extern "C" [[gnu::naked]] auto test_read_shcsr() {
+    return ArmCortex::Scb::SHCSR(ArmCortex::SCB->SHCSR);
 }
 
 // CHECK-LABEL: <test_read_shcsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #36]
+// CHECK-NEXT: ldr r0, [r3, #36]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 

--- a/tests/m0/test_special_regs.cpp
+++ b/tests/m0/test_special_regs.cpp
@@ -1,94 +1,91 @@
 #include "armcortex/m0/special_regs.hpp"
 
 // Test getLr()
-extern "C" [[gnu::naked]] void test_get_lr() {
-    uint32_t lr = ArmCortex::getLr();
-    (void)lr;
+extern "C" [[gnu::naked]] uint32_t test_get_lr() {
+    return ArmCortex::getLr();
 }
 
 // CHECK-LABEL: <test_get_lr>:
-// CHECK-NEXT: mov r3, lr
+
+// DEBUG-CHECK-NEXT: mov r0, lr
+
+// MINSIZE-CHECK-NEXT: mov r0, lr
+
+// MAXSPEED-CHECK-NEXT: mov r0, lr
 // MAXSPEED-CHECK-NEXT: nop
+
 // CHECK-EMPTY:
 
 // Test getApsrReg()
-extern "C" [[gnu::naked]] void test_get_apsr() {
-    ArmCortex::PSR apsr = ArmCortex::getApsrReg();
-    (void)apsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_apsr() {
+    return ArmCortex::getApsrReg();
 }
 
 // CHECK-LABEL: <test_get_apsr>:
-// CHECK-NEXT: mrs r3, CPSR
+// CHECK-NEXT: mrs r0, CPSR
 // CHECK-EMPTY:
 
 // Test getIpsrReg()
-extern "C" [[gnu::naked]] void test_get_ipsr() {
-    ArmCortex::PSR ipsr = ArmCortex::getIpsrReg();
-    (void)ipsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_ipsr() {
+    return ArmCortex::getIpsrReg();
 }
 
 // CHECK-LABEL: <test_get_ipsr>:
-// CHECK-NEXT: mrs r3, IPSR
+// CHECK-NEXT: mrs r0, IPSR
 // CHECK-EMPTY:
 
 // Test getEpsrReg()
-extern "C" [[gnu::naked]] void test_get_epsr() {
-    ArmCortex::PSR epsr = ArmCortex::getEpsrReg();
-    (void)epsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_epsr() {
+    return ArmCortex::getEpsrReg();
 }
 
 // CHECK-LABEL: <test_get_epsr>:
-// CHECK-NEXT: mrs r3, EPSR
+// CHECK-NEXT: mrs r0, EPSR
 // CHECK-EMPTY:
 
 // Test getIepsrReg()
-extern "C" [[gnu::naked]] void test_get_iepsr() {
-    ArmCortex::PSR iepsr = ArmCortex::getIepsrReg();
-    (void)iepsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_iepsr() {
+    return ArmCortex::getIepsrReg();
 }
 
 // CHECK-LABEL: <test_get_iepsr>:
-// CHECK-NEXT: mrs r3, IEPSR
+// CHECK-NEXT: mrs r0, IEPSR
 // CHECK-EMPTY:
 
 // Test getIapsrReg()
-extern "C" [[gnu::naked]] void test_get_iapsr() {
-    ArmCortex::PSR iapsr = ArmCortex::getIapsrReg();
-    (void)iapsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_iapsr() {
+    return ArmCortex::getIapsrReg();
 }
 
 // CHECK-LABEL: <test_get_iapsr>:
-// CHECK-NEXT: mrs r3, IAPSR
+// CHECK-NEXT: mrs r0, IAPSR
 // CHECK-EMPTY:
 
 // Test getEapsrReg()
-extern "C" [[gnu::naked]] void test_get_eapsr() {
-    ArmCortex::PSR eapsr = ArmCortex::getEapsrReg();
-    (void)eapsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_eapsr() {
+    return ArmCortex::getEapsrReg();
 }
 
 // CHECK-LABEL: <test_get_eapsr>:
-// CHECK-NEXT: mrs r3, EAPSR
+// CHECK-NEXT: mrs r0, EAPSR
 // CHECK-EMPTY:
 
 // Test getPsrReg()
-extern "C" [[gnu::naked]] void test_get_psr() {
-    ArmCortex::PSR psr = ArmCortex::getPsrReg();
-    (void)psr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_psr() {
+    return ArmCortex::getPsrReg();
 }
 
 // CHECK-LABEL: <test_get_psr>:
-// CHECK-NEXT: mrs r3, PSR
+// CHECK-NEXT: mrs r0, PSR
 // CHECK-EMPTY:
 
 // Test getMspReg()
-extern "C" [[gnu::naked]] void test_get_msp() {
-    uint32_t msp = ArmCortex::getMspReg();
-    (void)msp;
+extern "C" [[gnu::naked]] uint32_t test_get_msp() {
+    return ArmCortex::getMspReg();
 }
 
 // CHECK-LABEL: <test_get_msp>:
-// CHECK-NEXT: mrs r3, MSP
+// CHECK-NEXT: mrs r0, MSP
 // CHECK-EMPTY:
 
 // Test setMspReg()
@@ -97,20 +94,29 @@ extern "C" [[gnu::naked]] void test_set_msp() {
 }
 
 // CHECK-LABEL: <test_set_msp>:
-// CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: msr MSP, r3
+
+// DEBUG-CHECK-NEXT: ldr r3, [pc, #4]
+// DEBUG-CHECK-NEXT: msr MSP, r3
+// DEBUG-CHECK-NEXT: .word 0x20001000
+
+// MINSIZE-CHECK-NEXT: ldr r3, [pc, #4]
+// MINSIZE-CHECK-NEXT: msr MSP, r3
+// MINSIZE-CHECK-NEXT: .word 0x20001000
+
+// MAXSPEED-CHECK-NEXT: ldr r3, [pc, #4]
+// MAXSPEED-CHECK-NEXT: msr MSP, r3
 // MAXSPEED-CHECK-NEXT: nop
-// CHECK-NEXT: .word 0x20001000
+// MAXSPEED-CHECK-NEXT: .word 0x20001000
+
 // CHECK-EMPTY:
 
 // Test getPspReg()
-extern "C" [[gnu::naked]] void test_get_psp() {
-    uint32_t psp = ArmCortex::getPspReg();
-    (void)psp;
+extern "C" [[gnu::naked]] uint32_t test_get_psp() {
+    return ArmCortex::getPspReg();
 }
 
 // CHECK-LABEL: <test_get_psp>:
-// CHECK-NEXT: mrs r3, PSP
+// CHECK-NEXT: mrs r0, PSP
 // CHECK-EMPTY:
 
 // Test setPspReg()
@@ -119,20 +125,31 @@ extern "C" [[gnu::naked]] void test_set_psp() {
 }
 
 // CHECK-LABEL: <test_set_psp>:
-// CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: msr PSP, r3
-// CHECK-NEXT: nop
-// CHECK-NEXT: .word 0x20002000
+
+// DEBUG-CHECK-NEXT: ldr r3, [pc, #4]
+// DEBUG-CHECK-NEXT: msr PSP, r3
+// DEBUG-CHECK-NEXT: nop
+// DEBUG-CHECK-NEXT: .word 0x20002000
+
+// MINSIZE-CHECK-NEXT: ldr r3, [pc, #4]
+// MINSIZE-CHECK-NEXT: msr PSP, r3
+// MINSIZE-CHECK-NEXT: nop
+// MINSIZE-CHECK-NEXT: .word 0x20002000
+
+// MAXSPEED-CHECK-NEXT: ldr r3, [pc, #4]
+// MAXSPEED-CHECK-NEXT: msr PSP, r3
+// MAXSPEED-CHECK-NEXT: nop
+// MAXSPEED-CHECK-NEXT: .word 0x20002000
+
 // CHECK-EMPTY:
 
 // Test getPrimaskReg()
-extern "C" [[gnu::naked]] void test_get_primask() {
-    ArmCortex::PRIMASK primask = ArmCortex::getPrimaskReg();
-    (void)primask;
+extern "C" [[gnu::naked]] ArmCortex::PRIMASK test_get_primask() {
+    return ArmCortex::getPrimaskReg();
 }
 
 // CHECK-LABEL: <test_get_primask>:
-// CHECK-NEXT: mrs r3, PRIMASK
+// CHECK-NEXT: mrs r0, PRIMASK
 // CHECK-EMPTY:
 
 // Test setPrimaskReg()
@@ -143,19 +160,26 @@ extern "C" [[gnu::naked]] void test_set_primask() {
 }
 
 // CHECK-LABEL: <test_set_primask>:
-// CHECK-NEXT: movs r3, #1
-// CHECK-NEXT: msr PRIMASK, r3
+
+// DEBUG-CHECK-NEXT: movs r3, #1
+// DEBUG-CHECK-NEXT: msr PRIMASK, r3
+
+// MINSIZE-CHECK-NEXT: movs r3, #1
+// MINSIZE-CHECK-NEXT: msr PRIMASK, r3
+
+// MAXSPEED-CHECK-NEXT: movs r3, #1
+// MAXSPEED-CHECK-NEXT: msr PRIMASK, r3
 // MAXSPEED-CHECK-NEXT: nop
+
 // CHECK-EMPTY:
 
 // Test getControlReg()
-extern "C" [[gnu::naked]] void test_get_control() {
-    ArmCortex::CONTROL control = ArmCortex::getControlReg();
-    (void)control;
+extern "C" [[gnu::naked]] ArmCortex::CONTROL test_get_control() {
+    return ArmCortex::getControlReg();
 }
 
 // CHECK-LABEL: <test_get_control>:
-// CHECK-NEXT: mrs r3, CONTROL
+// CHECK-NEXT: mrs r0, CONTROL
 // CHECK-EMPTY:
 
 // Test setControlReg()
@@ -166,7 +190,15 @@ extern "C" [[gnu::naked]] void test_set_control() {
 }
 
 // CHECK-LABEL: <test_set_control>:
-// CHECK-NEXT: movs r3, #2
-// CHECK-NEXT: msr CONTROL, r3
+
+// DEBUG-CHECK-NEXT: movs r3, #2
+// DEBUG-CHECK-NEXT: msr CONTROL, r3
+
+// MINSIZE-CHECK-NEXT: movs r3, #2
+// MINSIZE-CHECK-NEXT: msr CONTROL, r3
+
+// MAXSPEED-CHECK-NEXT: movs r3, #2
+// MAXSPEED-CHECK-NEXT: msr CONTROL, r3
 // MAXSPEED-CHECK-NEXT: nop
+
 // CHECK-EMPTY:

--- a/tests/m0plus/test_mpu.cpp
+++ b/tests/m0plus/test_mpu.cpp
@@ -1,26 +1,24 @@
 #include "armcortex/m0plus/mpu.hpp"
 
 // Test reading TYPE register
-extern "C" [[gnu::naked]] void test_read_type() {
-    auto type = ArmCortex::Mpu::TYPE(ArmCortex::MPU->TYPE);
-    (void)type;
+extern "C" [[gnu::naked]] auto test_read_type() {
+    return ArmCortex::Mpu::TYPE(ArmCortex::MPU->TYPE);
 }
 
 // CHECK-LABEL: <test_read_type>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #0]
+// CHECK-NEXT: ldr r0, [r3, #0]
 // CHECK-NEXT: .word 0xe000ed90
 // CHECK-EMPTY:
 
 // Test reading CTRL register
-extern "C" [[gnu::naked]] void test_read_ctrl() {
-    auto ctrl = ArmCortex::Mpu::CTRL(ArmCortex::MPU->CTRL);
-    (void)ctrl;
+extern "C" [[gnu::naked]] auto test_read_ctrl() {
+    return ArmCortex::Mpu::CTRL(ArmCortex::MPU->CTRL);
 }
 
 // CHECK-LABEL: <test_read_ctrl>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #4]
+// CHECK-NEXT: ldr r0, [r3, #4]
 // CHECK-NEXT: .word 0xe000ed90
 // CHECK-EMPTY:
 
@@ -55,14 +53,13 @@ extern "C" [[gnu::naked]] void test_write_ctrl() {
 // CHECK-EMPTY:
 
 // Test reading RNR register
-extern "C" [[gnu::naked]] void test_read_rnr() {
-    uint32_t rnr = ArmCortex::MPU->RNR;
-    (void)rnr;
+extern "C" [[gnu::naked]] uint32_t test_read_rnr() {
+    return ArmCortex::MPU->RNR;
 }
 
 // CHECK-LABEL: <test_read_rnr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #8]
+// CHECK-NEXT: ldr r0, [r3, #8]
 // CHECK-NEXT: .word 0xe000ed90
 // CHECK-EMPTY:
 
@@ -94,14 +91,13 @@ extern "C" [[gnu::naked]] void test_write_rnr() {
 // CHECK-EMPTY:
 
 // Test reading RBAR register
-extern "C" [[gnu::naked]] void test_read_rbar() {
-    auto rbar = ArmCortex::Mpu::RBAR(ArmCortex::MPU->RBAR);
-    (void)rbar;
+extern "C" [[gnu::naked]] auto test_read_rbar() {
+    return ArmCortex::Mpu::RBAR(ArmCortex::MPU->RBAR);
 }
 
 // CHECK-LABEL: <test_read_rbar>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #12]
+// CHECK-NEXT: ldr r0, [r3, #12]
 // CHECK-NEXT: .word 0xe000ed90
 // CHECK-EMPTY:
 
@@ -124,14 +120,13 @@ extern "C" [[gnu::naked]] void test_write_rbar() {
 // CHECK-EMPTY:
 
 // Test reading RASR register
-extern "C" [[gnu::naked]] void test_read_rasr() {
-    auto rasr = ArmCortex::Mpu::RASR(ArmCortex::MPU->RASR);
-    (void)rasr;
+extern "C" [[gnu::naked]] auto test_read_rasr() {
+    return ArmCortex::Mpu::RASR(ArmCortex::MPU->RASR);
 }
 
 // CHECK-LABEL: <test_read_rasr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #16]
+// CHECK-NEXT: ldr r0, [r3, #16]
 // CHECK-NEXT: .word 0xe000ed90
 // CHECK-EMPTY:
 

--- a/tests/m0plus/test_nvic.cpp
+++ b/tests/m0plus/test_nvic.cpp
@@ -1,14 +1,13 @@
 #include "armcortex/m0plus/nvic.hpp"
 
 // Test isIrqEnabled()
-extern "C" [[gnu::naked]] void test_is_irq_enabled() {
-    bool enabled = ArmCortex::Nvic::isIrqEnabled(5);
-    (void)enabled;
+extern "C" [[gnu::naked]] bool test_is_irq_enabled() {
+    return ArmCortex::Nvic::isIrqEnabled(5);
 }
 
 // CHECK-LABEL: <test_is_irq_enabled>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #0]
+// CHECK-NEXT: ldr r0, [r3, #0]
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-EMPTY:
 
@@ -67,9 +66,8 @@ extern "C" [[gnu::naked]] void test_disable_irq() {
 // CHECK-EMPTY:
 
 // Test isIrqPending()
-extern "C" [[gnu::naked]] void test_is_irq_pending() {
-    bool pending = ArmCortex::Nvic::isIrqPending(3);
-    (void)pending;
+extern "C" [[gnu::naked]] bool test_is_irq_pending() {
+    return ArmCortex::Nvic::isIrqPending(3);
 }
 
 // CHECK-LABEL: <test_is_irq_pending>:
@@ -77,17 +75,17 @@ extern "C" [[gnu::naked]] void test_is_irq_pending() {
 // DEBUG-CHECK-NEXT: ldr r2, [pc, #4]
 // DEBUG-CHECK-NEXT: movs r3, #128
 // DEBUG-CHECK-NEXT: lsls r3, r3, #1
-// DEBUG-CHECK-NEXT: ldr r3, [r2, r3]
+// DEBUG-CHECK-NEXT: ldr r0, [r2, r3]
 // DEBUG-CHECK-NEXT: .word 0xe000e100
 
 // MINSIZE-CHECK-NEXT: ldr r3, [pc, #0]
-// MINSIZE-CHECK-NEXT: ldr r3, [r3, #4]
+// MINSIZE-CHECK-NEXT: ldr r0, [r3, #4]
 // MINSIZE-CHECK-NEXT: .word 0xe000e1fc
 
 // MAXSPEED-CHECK-NEXT: movs r3, #128
 // MAXSPEED-CHECK-NEXT: ldr r2, [pc, #4]
 // MAXSPEED-CHECK-NEXT: lsls r3, r3, #1
-// MAXSPEED-CHECK-NEXT: ldr r3, [r2, r3]
+// MAXSPEED-CHECK-NEXT: ldr r0, [r2, r3]
 // MAXSPEED-CHECK-NEXT: .word 0xe000e100
 
 // CHECK-EMPTY:
@@ -157,15 +155,14 @@ extern "C" [[gnu::naked]] void test_clear_pending_irq() {
 // CHECK-EMPTY:
 
 // Test reading IPR (interrupt priority)
-extern "C" [[gnu::naked]] void test_read_ipr() {
-    uint8_t priority = ArmCortex::NVIC->IPR[5];
-    (void)priority;
+extern "C" [[gnu::naked]] uint8_t test_read_ipr() {
+    return ArmCortex::NVIC->IPR[5];
 }
 
 // CHECK-LABEL: <test_read_ipr>:
 // CHECK-NEXT: ldr r2, [pc, #4]
 // CHECK-NEXT: ldr r3, [pc, #8]
-// CHECK-NEXT: ldrb r3, [r2, r3]
+// CHECK-NEXT: ldrb r0, [r2, r3]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-NEXT: .word 0x00000305

--- a/tests/m0plus/test_nvic.cpp
+++ b/tests/m0plus/test_nvic.cpp
@@ -6,8 +6,10 @@ extern "C" [[gnu::naked]] bool test_is_irq_enabled() {
 }
 
 // CHECK-LABEL: <test_is_irq_enabled>:
-// CHECK-NEXT: ldr r3, [pc, #0]
+// CHECK-NEXT: ldr r3, [pc, #4]
 // CHECK-NEXT: ldr r0, [r3, #0]
+// CHECK-NEXT: lsls r0, r0, #26
+// CHECK-NEXT: lsrs r0, r0, #31
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-EMPTY:
 
@@ -72,20 +74,26 @@ extern "C" [[gnu::naked]] bool test_is_irq_pending() {
 
 // CHECK-LABEL: <test_is_irq_pending>:
 
-// DEBUG-CHECK-NEXT: ldr r2, [pc, #4]
+// DEBUG-CHECK-NEXT: ldr r2, [pc, #8]
 // DEBUG-CHECK-NEXT: movs r3, #128
 // DEBUG-CHECK-NEXT: lsls r3, r3, #1
 // DEBUG-CHECK-NEXT: ldr r0, [r2, r3]
+// DEBUG-CHECK-NEXT: lsls r0, r0, #28
+// DEBUG-CHECK-NEXT: lsrs r0, r0, #31
 // DEBUG-CHECK-NEXT: .word 0xe000e100
 
-// MINSIZE-CHECK-NEXT: ldr r3, [pc, #0]
+// MINSIZE-CHECK-NEXT: ldr r3, [pc, #4]
 // MINSIZE-CHECK-NEXT: ldr r0, [r3, #4]
+// MINSIZE-CHECK-NEXT: lsls r0, r0, #28
+// MINSIZE-CHECK-NEXT: lsrs r0, r0, #31
 // MINSIZE-CHECK-NEXT: .word 0xe000e1fc
 
 // MAXSPEED-CHECK-NEXT: movs r3, #128
-// MAXSPEED-CHECK-NEXT: ldr r2, [pc, #4]
+// MAXSPEED-CHECK-NEXT: ldr r2, [pc, #8]
 // MAXSPEED-CHECK-NEXT: lsls r3, r3, #1
 // MAXSPEED-CHECK-NEXT: ldr r0, [r2, r3]
+// MAXSPEED-CHECK-NEXT: lsls r0, r0, #28
+// MAXSPEED-CHECK-NEXT: lsrs r0, r0, #31
 // MAXSPEED-CHECK-NEXT: .word 0xe000e100
 
 // CHECK-EMPTY:
@@ -163,7 +171,7 @@ extern "C" [[gnu::naked]] uint8_t test_read_ipr() {
 // CHECK-NEXT: ldr r2, [pc, #4]
 // CHECK-NEXT: ldr r3, [pc, #8]
 // CHECK-NEXT: ldrb r0, [r2, r3]
-// CHECK-NEXT: nop
+// CHECK-NEXT: uxtb r0, r0
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-NEXT: .word 0x00000305
 // CHECK-EMPTY:

--- a/tests/m0plus/test_scb.cpp
+++ b/tests/m0plus/test_scb.cpp
@@ -1,26 +1,24 @@
 #include "armcortex/m0plus/scb.hpp"
 
 // Test reading CPUID register
-extern "C" [[gnu::naked]] void test_read_cpuid() {
-    auto cpuid = ArmCortex::Scb::CPUID(ArmCortex::SCB->CPUID);
-    (void)cpuid;
+extern "C" [[gnu::naked]] auto test_read_cpuid() {
+    return ArmCortex::Scb::CPUID(ArmCortex::SCB->CPUID);
 }
 
 // CHECK-LABEL: <test_read_cpuid>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #0]
+// CHECK-NEXT: ldr r0, [r3, #0]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
 // Test reading ICSR register
-extern "C" [[gnu::naked]] void test_read_icsr() {
-    auto icsr = ArmCortex::Scb::ICSR(ArmCortex::SCB->ICSR);
-    (void)icsr;
+extern "C" [[gnu::naked]] auto test_read_icsr() {
+    return ArmCortex::Scb::ICSR(ArmCortex::SCB->ICSR);
 }
 
 // CHECK-LABEL: <test_read_icsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #4]
+// CHECK-NEXT: ldr r0, [r3, #4]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -54,14 +52,13 @@ extern "C" [[gnu::naked]] void test_write_icsr() {
 // CHECK-EMPTY:
 
 // Test reading VTOR register (M0+ has VTOR, unlike M0)
-extern "C" [[gnu::naked]] void test_read_vtor() {
-    uint32_t vtor = ArmCortex::SCB->VTOR;
-    (void)vtor;
+extern "C" [[gnu::naked]] uint32_t test_read_vtor() {
+    return ArmCortex::SCB->VTOR;
 }
 
 // CHECK-LABEL: <test_read_vtor>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #8]
+// CHECK-NEXT: ldr r0, [r3, #8]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -93,14 +90,13 @@ extern "C" [[gnu::naked]] void test_write_vtor() {
 // CHECK-EMPTY:
 
 // Test reading AIRCR register
-extern "C" [[gnu::naked]] void test_read_aircr() {
-    auto aircr = ArmCortex::Scb::AIRCR(ArmCortex::SCB->AIRCR);
-    (void)aircr;
+extern "C" [[gnu::naked]] auto test_read_aircr() {
+    return ArmCortex::Scb::AIRCR(ArmCortex::SCB->AIRCR);
 }
 
 // CHECK-LABEL: <test_read_aircr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #12]
+// CHECK-NEXT: ldr r0, [r3, #12]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -122,14 +118,13 @@ extern "C" [[gnu::naked]] void test_write_aircr() {
 // CHECK-EMPTY:
 
 // Test reading SCR register
-extern "C" [[gnu::naked]] void test_read_scr() {
-    auto scr = ArmCortex::Scb::SCR(ArmCortex::SCB->SCR);
-    (void)scr;
+extern "C" [[gnu::naked]] auto test_read_scr() {
+    return ArmCortex::Scb::SCR(ArmCortex::SCB->SCR);
 }
 
 // CHECK-LABEL: <test_read_scr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #16]
+// CHECK-NEXT: ldr r0, [r3, #16]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -163,26 +158,24 @@ extern "C" [[gnu::naked]] void test_write_scr() {
 // CHECK-EMPTY:
 
 // Test reading CCR register
-extern "C" [[gnu::naked]] void test_read_ccr() {
-    auto ccr = ArmCortex::Scb::CCR(ArmCortex::SCB->CCR);
-    (void)ccr;
+extern "C" [[gnu::naked]] auto test_read_ccr() {
+    return ArmCortex::Scb::CCR(ArmCortex::SCB->CCR);
 }
 
 // CHECK-LABEL: <test_read_ccr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #20]
+// CHECK-NEXT: ldr r0, [r3, #20]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
 // Test reading SHPR2 register
-extern "C" [[gnu::naked]] void test_read_shpr2() {
-    auto shpr2 = ArmCortex::Scb::SHPR2(ArmCortex::SCB->SHPR2);
-    (void)shpr2;
+extern "C" [[gnu::naked]] auto test_read_shpr2() {
+    return ArmCortex::Scb::SHPR2(ArmCortex::SCB->SHPR2);
 }
 
 // CHECK-LABEL: <test_read_shpr2>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #28]
+// CHECK-NEXT: ldr r0, [r3, #28]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -216,14 +209,13 @@ extern "C" [[gnu::naked]] void test_write_shpr2() {
 // CHECK-EMPTY:
 
 // Test reading SHPR3 register
-extern "C" [[gnu::naked]] void test_read_shpr3() {
-    auto shpr3 = ArmCortex::Scb::SHPR3(ArmCortex::SCB->SHPR3);
-    (void)shpr3;
+extern "C" [[gnu::naked]] auto test_read_shpr3() {
+    return ArmCortex::Scb::SHPR3(ArmCortex::SCB->SHPR3);
 }
 
 // CHECK-LABEL: <test_read_shpr3>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #32]
+// CHECK-NEXT: ldr r0, [r3, #32]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -245,14 +237,13 @@ extern "C" [[gnu::naked]] void test_write_shpr3() {
 // CHECK-EMPTY:
 
 // Test reading SHCSR register
-extern "C" [[gnu::naked]] void test_read_shcsr() {
-    auto shcsr = ArmCortex::Scb::SHCSR(ArmCortex::SCB->SHCSR);
-    (void)shcsr;
+extern "C" [[gnu::naked]] auto test_read_shcsr() {
+    return ArmCortex::Scb::SHCSR(ArmCortex::SCB->SHCSR);
 }
 
 // CHECK-LABEL: <test_read_shcsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #36]
+// CHECK-NEXT: ldr r0, [r3, #36]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 

--- a/tests/m0plus/test_special_regs.cpp
+++ b/tests/m0plus/test_special_regs.cpp
@@ -6,8 +6,14 @@ extern "C" [[gnu::naked]] uint32_t test_get_lr() {
 }
 
 // CHECK-LABEL: <test_get_lr>:
-// CHECK-NEXT: mov r0, lr
+
+// DEBUG-CHECK-NEXT: mov r0, lr
+
+// MINSIZE-CHECK-NEXT: mov r0, lr
+
+// MAXSPEED-CHECK-NEXT: mov r0, lr
 // MAXSPEED-CHECK-NEXT: nop
+
 // CHECK-EMPTY:
 
 // Test getApsrReg()
@@ -88,10 +94,20 @@ extern "C" [[gnu::naked]] void test_set_msp() {
 }
 
 // CHECK-LABEL: <test_set_msp>:
-// CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: msr MSP, r3
+
+// DEBUG-CHECK-NEXT: ldr r3, [pc, #4]
+// DEBUG-CHECK-NEXT: msr MSP, r3
+// DEBUG-CHECK-NEXT: .word 0x20001000
+
+// MINSIZE-CHECK-NEXT: ldr r3, [pc, #4]
+// MINSIZE-CHECK-NEXT: msr MSP, r3
+// MINSIZE-CHECK-NEXT: .word 0x20001000
+
+// MAXSPEED-CHECK-NEXT: ldr r3, [pc, #4]
+// MAXSPEED-CHECK-NEXT: msr MSP, r3
 // MAXSPEED-CHECK-NEXT: nop
-// CHECK-NEXT: .word 0x20001000
+// MAXSPEED-CHECK-NEXT: .word 0x20001000
+
 // CHECK-EMPTY:
 
 // Test getPspReg()
@@ -109,10 +125,22 @@ extern "C" [[gnu::naked]] void test_set_psp() {
 }
 
 // CHECK-LABEL: <test_set_psp>:
-// CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: msr PSP, r3
-// CHECK-NEXT: nop
-// CHECK-NEXT: .word 0x20002000
+
+// DEBUG-CHECK-NEXT: ldr r3, [pc, #4]
+// DEBUG-CHECK-NEXT: msr PSP, r3
+// DEBUG-CHECK-NEXT: nop
+// DEBUG-CHECK-NEXT: .word 0x20002000
+
+// MINSIZE-CHECK-NEXT: ldr r3, [pc, #4]
+// MINSIZE-CHECK-NEXT: msr PSP, r3
+// MINSIZE-CHECK-NEXT: nop
+// MINSIZE-CHECK-NEXT: .word 0x20002000
+
+// MAXSPEED-CHECK-NEXT: ldr r3, [pc, #4]
+// MAXSPEED-CHECK-NEXT: msr PSP, r3
+// MAXSPEED-CHECK-NEXT: nop
+// MAXSPEED-CHECK-NEXT: .word 0x20002000
+
 // CHECK-EMPTY:
 
 // Test getPrimaskReg()
@@ -132,9 +160,17 @@ extern "C" [[gnu::naked]] void test_set_primask() {
 }
 
 // CHECK-LABEL: <test_set_primask>:
-// CHECK-NEXT: movs r3, #1
-// CHECK-NEXT: msr PRIMASK, r3
+
+// DEBUG-CHECK-NEXT: movs r3, #1
+// DEBUG-CHECK-NEXT: msr PRIMASK, r3
+
+// MINSIZE-CHECK-NEXT: movs r3, #1
+// MINSIZE-CHECK-NEXT: msr PRIMASK, r3
+
+// MAXSPEED-CHECK-NEXT: movs r3, #1
+// MAXSPEED-CHECK-NEXT: msr PRIMASK, r3
 // MAXSPEED-CHECK-NEXT: nop
+
 // CHECK-EMPTY:
 
 // Test getControlReg()
@@ -154,7 +190,15 @@ extern "C" [[gnu::naked]] void test_set_control() {
 }
 
 // CHECK-LABEL: <test_set_control>:
-// CHECK-NEXT: movs r3, #2
-// CHECK-NEXT: msr CONTROL, r3
+
+// DEBUG-CHECK-NEXT: movs r3, #2
+// DEBUG-CHECK-NEXT: msr CONTROL, r3
+
+// MINSIZE-CHECK-NEXT: movs r3, #2
+// MINSIZE-CHECK-NEXT: msr CONTROL, r3
+
+// MAXSPEED-CHECK-NEXT: movs r3, #2
+// MAXSPEED-CHECK-NEXT: msr CONTROL, r3
 // MAXSPEED-CHECK-NEXT: nop
+
 // CHECK-EMPTY:

--- a/tests/m0plus/test_special_regs.cpp
+++ b/tests/m0plus/test_special_regs.cpp
@@ -1,94 +1,85 @@
 #include "armcortex/m0plus/special_regs.hpp"
 
 // Test getLr()
-extern "C" [[gnu::naked]] void test_get_lr() {
-    uint32_t lr = ArmCortex::getLr();
-    (void)lr;
+extern "C" [[gnu::naked]] uint32_t test_get_lr() {
+    return ArmCortex::getLr();
 }
 
 // CHECK-LABEL: <test_get_lr>:
-// CHECK-NEXT: mov r3, lr
+// CHECK-NEXT: mov r0, lr
 // MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test getApsrReg()
-extern "C" [[gnu::naked]] void test_get_apsr() {
-    ArmCortex::PSR apsr = ArmCortex::getApsrReg();
-    (void)apsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_apsr() {
+    return ArmCortex::getApsrReg();
 }
 
 // CHECK-LABEL: <test_get_apsr>:
-// CHECK-NEXT: mrs r3, CPSR
+// CHECK-NEXT: mrs r0, CPSR
 // CHECK-EMPTY:
 
 // Test getIpsrReg()
-extern "C" [[gnu::naked]] void test_get_ipsr() {
-    ArmCortex::PSR ipsr = ArmCortex::getIpsrReg();
-    (void)ipsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_ipsr() {
+    return ArmCortex::getIpsrReg();
 }
 
 // CHECK-LABEL: <test_get_ipsr>:
-// CHECK-NEXT: mrs r3, IPSR
+// CHECK-NEXT: mrs r0, IPSR
 // CHECK-EMPTY:
 
 // Test getEpsrReg()
-extern "C" [[gnu::naked]] void test_get_epsr() {
-    ArmCortex::PSR epsr = ArmCortex::getEpsrReg();
-    (void)epsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_epsr() {
+    return ArmCortex::getEpsrReg();
 }
 
 // CHECK-LABEL: <test_get_epsr>:
-// CHECK-NEXT: mrs r3, EPSR
+// CHECK-NEXT: mrs r0, EPSR
 // CHECK-EMPTY:
 
 // Test getIepsrReg()
-extern "C" [[gnu::naked]] void test_get_iepsr() {
-    ArmCortex::PSR iepsr = ArmCortex::getIepsrReg();
-    (void)iepsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_iepsr() {
+    return ArmCortex::getIepsrReg();
 }
 
 // CHECK-LABEL: <test_get_iepsr>:
-// CHECK-NEXT: mrs r3, IEPSR
+// CHECK-NEXT: mrs r0, IEPSR
 // CHECK-EMPTY:
 
 // Test getIapsrReg()
-extern "C" [[gnu::naked]] void test_get_iapsr() {
-    ArmCortex::PSR iapsr = ArmCortex::getIapsrReg();
-    (void)iapsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_iapsr() {
+    return ArmCortex::getIapsrReg();
 }
 
 // CHECK-LABEL: <test_get_iapsr>:
-// CHECK-NEXT: mrs r3, IAPSR
+// CHECK-NEXT: mrs r0, IAPSR
 // CHECK-EMPTY:
 
 // Test getEapsrReg()
-extern "C" [[gnu::naked]] void test_get_eapsr() {
-    ArmCortex::PSR eapsr = ArmCortex::getEapsrReg();
-    (void)eapsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_eapsr() {
+    return ArmCortex::getEapsrReg();
 }
 
 // CHECK-LABEL: <test_get_eapsr>:
-// CHECK-NEXT: mrs r3, EAPSR
+// CHECK-NEXT: mrs r0, EAPSR
 // CHECK-EMPTY:
 
 // Test getPsrReg()
-extern "C" [[gnu::naked]] void test_get_psr() {
-    ArmCortex::PSR psr = ArmCortex::getPsrReg();
-    (void)psr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_psr() {
+    return ArmCortex::getPsrReg();
 }
 
 // CHECK-LABEL: <test_get_psr>:
-// CHECK-NEXT: mrs r3, PSR
+// CHECK-NEXT: mrs r0, PSR
 // CHECK-EMPTY:
 
 // Test getMspReg()
-extern "C" [[gnu::naked]] void test_get_msp() {
-    uint32_t msp = ArmCortex::getMspReg();
-    (void)msp;
+extern "C" [[gnu::naked]] uint32_t test_get_msp() {
+    return ArmCortex::getMspReg();
 }
 
 // CHECK-LABEL: <test_get_msp>:
-// CHECK-NEXT: mrs r3, MSP
+// CHECK-NEXT: mrs r0, MSP
 // CHECK-EMPTY:
 
 // Test setMspReg()
@@ -104,13 +95,12 @@ extern "C" [[gnu::naked]] void test_set_msp() {
 // CHECK-EMPTY:
 
 // Test getPspReg()
-extern "C" [[gnu::naked]] void test_get_psp() {
-    uint32_t psp = ArmCortex::getPspReg();
-    (void)psp;
+extern "C" [[gnu::naked]] uint32_t test_get_psp() {
+    return ArmCortex::getPspReg();
 }
 
 // CHECK-LABEL: <test_get_psp>:
-// CHECK-NEXT: mrs r3, PSP
+// CHECK-NEXT: mrs r0, PSP
 // CHECK-EMPTY:
 
 // Test setPspReg()
@@ -126,13 +116,12 @@ extern "C" [[gnu::naked]] void test_set_psp() {
 // CHECK-EMPTY:
 
 // Test getPrimaskReg()
-extern "C" [[gnu::naked]] void test_get_primask() {
-    ArmCortex::PRIMASK primask = ArmCortex::getPrimaskReg();
-    (void)primask;
+extern "C" [[gnu::naked]] ArmCortex::PRIMASK test_get_primask() {
+    return ArmCortex::getPrimaskReg();
 }
 
 // CHECK-LABEL: <test_get_primask>:
-// CHECK-NEXT: mrs r3, PRIMASK
+// CHECK-NEXT: mrs r0, PRIMASK
 // CHECK-EMPTY:
 
 // Test setPrimaskReg()
@@ -149,13 +138,12 @@ extern "C" [[gnu::naked]] void test_set_primask() {
 // CHECK-EMPTY:
 
 // Test getControlReg()
-extern "C" [[gnu::naked]] void test_get_control() {
-    ArmCortex::CONTROL control = ArmCortex::getControlReg();
-    (void)control;
+extern "C" [[gnu::naked]] ArmCortex::CONTROL test_get_control() {
+    return ArmCortex::getControlReg();
 }
 
 // CHECK-LABEL: <test_get_control>:
-// CHECK-NEXT: mrs r3, CONTROL
+// CHECK-NEXT: mrs r0, CONTROL
 // CHECK-EMPTY:
 
 // Test setControlReg()

--- a/tests/m0plus/test_systick.cpp
+++ b/tests/m0plus/test_systick.cpp
@@ -1,14 +1,13 @@
 #include "armcortex/m0plus/systick.hpp"
 
 // Test reading CTRL register
-extern "C" [[gnu::naked]] void test_read_ctrl() {
-    auto ctrl = ArmCortex::SysTick::CTRL(ArmCortex::SYS_TICK->CTRL);
-    (void)ctrl;
+extern "C" [[gnu::naked]] auto test_read_ctrl() {
+    return ArmCortex::SysTick::CTRL(ArmCortex::SYS_TICK->CTRL);
 }
 
 // CHECK-LABEL: <test_read_ctrl>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #0]
+// CHECK-NEXT: ldr r0, [r3, #0]
 // CHECK-NEXT: .word 0xe000e010
 // CHECK-EMPTY:
 
@@ -44,14 +43,13 @@ extern "C" [[gnu::naked]] void test_write_ctrl() {
 // CHECK-EMPTY:
 
 // Test reading LOAD register
-extern "C" [[gnu::naked]] void test_read_load() {
-    uint32_t load = ArmCortex::SYS_TICK->LOAD;
-    (void)load;
+extern "C" [[gnu::naked]] uint32_t test_read_load() {
+    return ArmCortex::SYS_TICK->LOAD;
 }
 
 // CHECK-LABEL: <test_read_load>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #4]
+// CHECK-NEXT: ldr r0, [r3, #4]
 // CHECK-NEXT: .word 0xe000e010
 // CHECK-EMPTY:
 
@@ -70,14 +68,13 @@ extern "C" [[gnu::naked]] void test_write_load() {
 // CHECK-EMPTY:
 
 // Test reading VAL register
-extern "C" [[gnu::naked]] void test_read_val() {
-    uint32_t val = ArmCortex::SYS_TICK->VAL;
-    (void)val;
+extern "C" [[gnu::naked]] uint32_t test_read_val() {
+    return ArmCortex::SYS_TICK->VAL;
 }
 
 // CHECK-LABEL: <test_read_val>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #8]
+// CHECK-NEXT: ldr r0, [r3, #8]
 // CHECK-NEXT: .word 0xe000e010
 // CHECK-EMPTY:
 
@@ -109,14 +106,13 @@ extern "C" [[gnu::naked]] void test_write_val() {
 // CHECK-EMPTY:
 
 // Test reading CALIB register
-extern "C" [[gnu::naked]] void test_read_calib() {
-    auto calib = ArmCortex::SysTick::CALIB(ArmCortex::SYS_TICK->CALIB);
-    (void)calib;
+extern "C" [[gnu::naked]] auto test_read_calib() {
+    return ArmCortex::SysTick::CALIB(ArmCortex::SYS_TICK->CALIB);
 }
 
 // CHECK-LABEL: <test_read_calib>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #12]
+// CHECK-NEXT: ldr r0, [r3, #12]
 // CHECK-NEXT: .word 0xe000e010
 // CHECK-EMPTY:
 

--- a/tests/m1/test_nvic.cpp
+++ b/tests/m1/test_nvic.cpp
@@ -1,14 +1,15 @@
 #include "armcortex/m1/nvic.hpp"
 
 // Test isIrqEnabled()
-extern "C" [[gnu::naked]] void test_is_irq_enabled() {
-    bool enabled = ArmCortex::Nvic::isIrqEnabled(5);
-    (void)enabled;
+extern "C" [[gnu::naked]] bool test_is_irq_enabled() {
+    return ArmCortex::Nvic::isIrqEnabled(5);
 }
 
 // CHECK-LABEL: <test_is_irq_enabled>:
-// CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #0]
+// CHECK-NEXT: ldr r3, [pc, #4]
+// CHECK-NEXT: ldr r0, [r3, #0]
+// CHECK-NEXT: lsls r0, r0, #26
+// CHECK-NEXT: lsrs r0, r0, #31
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-EMPTY:
 
@@ -67,27 +68,32 @@ extern "C" [[gnu::naked]] void test_disable_irq() {
 // CHECK-EMPTY:
 
 // Test isIrqPending()
-extern "C" [[gnu::naked]] void test_is_irq_pending() {
-    bool pending = ArmCortex::Nvic::isIrqPending(3);
-    (void)pending;
+extern "C" [[gnu::naked]] bool test_is_irq_pending() {
+    return ArmCortex::Nvic::isIrqPending(3);
 }
 
 // CHECK-LABEL: <test_is_irq_pending>:
 
-// DEBUG-CHECK-NEXT: ldr r2, [pc, #4]
+// DEBUG-CHECK-NEXT: ldr r2, [pc, #8]
 // DEBUG-CHECK-NEXT: movs r3, #128
 // DEBUG-CHECK-NEXT: lsls r3, r3, #1
-// DEBUG-CHECK-NEXT: ldr r3, [r2, r3]
+// DEBUG-CHECK-NEXT: ldr r0, [r2, r3]
+// DEBUG-CHECK-NEXT: lsls r0, r0, #28
+// DEBUG-CHECK-NEXT: lsrs r0, r0, #31
 // DEBUG-CHECK-NEXT: .word 0xe000e100
 
-// MINSIZE-CHECK-NEXT: ldr r3, [pc, #0]
-// MINSIZE-CHECK-NEXT: ldr r3, [r3, #4]
+// MINSIZE-CHECK-NEXT: ldr r3, [pc, #4]
+// MINSIZE-CHECK-NEXT: ldr r0, [r3, #4]
+// MINSIZE-CHECK-NEXT: lsls r0, r0, #28
+// MINSIZE-CHECK-NEXT: lsrs r0, r0, #31
 // MINSIZE-CHECK-NEXT: .word 0xe000e1fc
 
 // MAXSPEED-CHECK-NEXT: movs r3, #128
-// MAXSPEED-CHECK-NEXT: ldr r2, [pc, #4]
+// MAXSPEED-CHECK-NEXT: ldr r2, [pc, #8]
 // MAXSPEED-CHECK-NEXT: lsls r3, r3, #1
-// MAXSPEED-CHECK-NEXT: ldr r3, [r2, r3]
+// MAXSPEED-CHECK-NEXT: ldr r0, [r2, r3]
+// MAXSPEED-CHECK-NEXT: lsls r0, r0, #28
+// MAXSPEED-CHECK-NEXT: lsrs r0, r0, #31
 // MAXSPEED-CHECK-NEXT: .word 0xe000e100
 
 // CHECK-EMPTY:
@@ -157,16 +163,15 @@ extern "C" [[gnu::naked]] void test_clear_pending_irq() {
 // CHECK-EMPTY:
 
 // Test reading IPR (interrupt priority)
-extern "C" [[gnu::naked]] void test_read_ipr() {
-    uint8_t priority = ArmCortex::NVIC->IPR[5];
-    (void)priority;
+extern "C" [[gnu::naked]] uint8_t test_read_ipr() {
+    return ArmCortex::NVIC->IPR[5];
 }
 
 // CHECK-LABEL: <test_read_ipr>:
 // CHECK-NEXT: ldr r2, [pc, #4]
 // CHECK-NEXT: ldr r3, [pc, #8]
-// CHECK-NEXT: ldrb r3, [r2, r3]
-// CHECK-NEXT: nop
+// CHECK-NEXT: ldrb r0, [r2, r3]
+// CHECK-NEXT: uxtb r0, r0
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-NEXT: .word 0x00000305
 // CHECK-EMPTY:

--- a/tests/m1/test_scb.cpp
+++ b/tests/m1/test_scb.cpp
@@ -1,26 +1,24 @@
 #include "armcortex/m1/scb.hpp"
 
 // Test reading CPUID register
-extern "C" [[gnu::naked]] void test_read_cpuid() {
-    auto cpuid = ArmCortex::Scb::CPUID(ArmCortex::SCB->CPUID);
-    (void)cpuid;
+extern "C" [[gnu::naked]] auto test_read_cpuid() {
+    return ArmCortex::Scb::CPUID(ArmCortex::SCB->CPUID);
 }
 
 // CHECK-LABEL: <test_read_cpuid>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #0]
+// CHECK-NEXT: ldr r0, [r3, #0]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
 // Test reading ICSR register
-extern "C" [[gnu::naked]] void test_read_icsr() {
-    auto icsr = ArmCortex::Scb::ICSR(ArmCortex::SCB->ICSR);
-    (void)icsr;
+extern "C" [[gnu::naked]] auto test_read_icsr() {
+    return ArmCortex::Scb::ICSR(ArmCortex::SCB->ICSR);
 }
 
 // CHECK-LABEL: <test_read_icsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #4]
+// CHECK-NEXT: ldr r0, [r3, #4]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -56,14 +54,13 @@ extern "C" [[gnu::naked]] void test_write_icsr() {
 // Note: M1 does not have VTOR register (unlike M0Plus)
 
 // Test reading AIRCR register
-extern "C" [[gnu::naked]] void test_read_aircr() {
-    auto aircr = ArmCortex::Scb::AIRCR(ArmCortex::SCB->AIRCR);
-    (void)aircr;
+extern "C" [[gnu::naked]] auto test_read_aircr() {
+    return ArmCortex::Scb::AIRCR(ArmCortex::SCB->AIRCR);
 }
 
 // CHECK-LABEL: <test_read_aircr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #12]
+// CHECK-NEXT: ldr r0, [r3, #12]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -85,14 +82,13 @@ extern "C" [[gnu::naked]] void test_write_aircr() {
 // CHECK-EMPTY:
 
 // Test reading SCR register
-extern "C" [[gnu::naked]] void test_read_scr() {
-    auto scr = ArmCortex::Scb::SCR(ArmCortex::SCB->SCR);
-    (void)scr;
+extern "C" [[gnu::naked]] auto test_read_scr() {
+    return ArmCortex::Scb::SCR(ArmCortex::SCB->SCR);
 }
 
 // CHECK-LABEL: <test_read_scr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #16]
+// CHECK-NEXT: ldr r0, [r3, #16]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -126,26 +122,24 @@ extern "C" [[gnu::naked]] void test_write_scr() {
 // CHECK-EMPTY:
 
 // Test reading CCR register
-extern "C" [[gnu::naked]] void test_read_ccr() {
-    auto ccr = ArmCortex::Scb::CCR(ArmCortex::SCB->CCR);
-    (void)ccr;
+extern "C" [[gnu::naked]] auto test_read_ccr() {
+    return ArmCortex::Scb::CCR(ArmCortex::SCB->CCR);
 }
 
 // CHECK-LABEL: <test_read_ccr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #20]
+// CHECK-NEXT: ldr r0, [r3, #20]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
 // Test reading SHPR2 register
-extern "C" [[gnu::naked]] void test_read_shpr2() {
-    auto shpr2 = ArmCortex::Scb::SHPR2(ArmCortex::SCB->SHPR2);
-    (void)shpr2;
+extern "C" [[gnu::naked]] auto test_read_shpr2() {
+    return ArmCortex::Scb::SHPR2(ArmCortex::SCB->SHPR2);
 }
 
 // CHECK-LABEL: <test_read_shpr2>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #28]
+// CHECK-NEXT: ldr r0, [r3, #28]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -179,14 +173,13 @@ extern "C" [[gnu::naked]] void test_write_shpr2() {
 // CHECK-EMPTY:
 
 // Test reading SHPR3 register
-extern "C" [[gnu::naked]] void test_read_shpr3() {
-    auto shpr3 = ArmCortex::Scb::SHPR3(ArmCortex::SCB->SHPR3);
-    (void)shpr3;
+extern "C" [[gnu::naked]] auto test_read_shpr3() {
+    return ArmCortex::Scb::SHPR3(ArmCortex::SCB->SHPR3);
 }
 
 // CHECK-LABEL: <test_read_shpr3>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #32]
+// CHECK-NEXT: ldr r0, [r3, #32]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -208,14 +201,13 @@ extern "C" [[gnu::naked]] void test_write_shpr3() {
 // CHECK-EMPTY:
 
 // Test reading SHCSR register
-extern "C" [[gnu::naked]] void test_read_shcsr() {
-    auto shcsr = ArmCortex::Scb::SHCSR(ArmCortex::SCB->SHCSR);
-    (void)shcsr;
+extern "C" [[gnu::naked]] auto test_read_shcsr() {
+    return ArmCortex::Scb::SHCSR(ArmCortex::SCB->SHCSR);
 }
 
 // CHECK-LABEL: <test_read_shcsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #36]
+// CHECK-NEXT: ldr r0, [r3, #36]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 

--- a/tests/m1/test_scnscb.cpp
+++ b/tests/m1/test_scnscb.cpp
@@ -1,14 +1,13 @@
 #include "armcortex/m1/scnscb.hpp"
 
 // Test reading ACTLR register
-extern "C" [[gnu::naked]] void test_read_actlr() {
-    auto actlr = ArmCortex::ScnScb::ACTLR(ArmCortex::SCN_SCB->ACTLR);
-    (void)actlr;
+extern "C" [[gnu::naked]] auto test_read_actlr() {
+    return ArmCortex::ScnScb::ACTLR(ArmCortex::SCN_SCB->ACTLR);
 }
 
 // CHECK-LABEL: <test_read_actlr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #8]
+// CHECK-NEXT: ldr r0, [r3, #8]
 // CHECK-NEXT: .word 0xe000e000
 // CHECK-EMPTY:
 

--- a/tests/m1/test_special_regs.cpp
+++ b/tests/m1/test_special_regs.cpp
@@ -1,94 +1,91 @@
 #include "armcortex/m1/special_regs.hpp"
 
 // Test getLr()
-extern "C" [[gnu::naked]] void test_get_lr() {
-    uint32_t lr = ArmCortex::getLr();
-    (void)lr;
+extern "C" [[gnu::naked]] uint32_t test_get_lr() {
+    return ArmCortex::getLr();
 }
 
 // CHECK-LABEL: <test_get_lr>:
-// CHECK-NEXT: mov r3, lr
+
+// DEBUG-CHECK-NEXT: mov r0, lr
+
+// MINSIZE-CHECK-NEXT: mov r0, lr
+
+// MAXSPEED-CHECK-NEXT: mov r0, lr
 // MAXSPEED-CHECK-NEXT: nop
+
 // CHECK-EMPTY:
 
 // Test getApsrReg()
-extern "C" [[gnu::naked]] void test_get_apsr() {
-    ArmCortex::PSR apsr = ArmCortex::getApsrReg();
-    (void)apsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_apsr() {
+    return ArmCortex::getApsrReg();
 }
 
 // CHECK-LABEL: <test_get_apsr>:
-// CHECK-NEXT: mrs r3, CPSR
+// CHECK-NEXT: mrs r0, CPSR
 // CHECK-EMPTY:
 
 // Test getIpsrReg()
-extern "C" [[gnu::naked]] void test_get_ipsr() {
-    ArmCortex::PSR ipsr = ArmCortex::getIpsrReg();
-    (void)ipsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_ipsr() {
+    return ArmCortex::getIpsrReg();
 }
 
 // CHECK-LABEL: <test_get_ipsr>:
-// CHECK-NEXT: mrs r3, IPSR
+// CHECK-NEXT: mrs r0, IPSR
 // CHECK-EMPTY:
 
 // Test getEpsrReg()
-extern "C" [[gnu::naked]] void test_get_epsr() {
-    ArmCortex::PSR epsr = ArmCortex::getEpsrReg();
-    (void)epsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_epsr() {
+    return ArmCortex::getEpsrReg();
 }
 
 // CHECK-LABEL: <test_get_epsr>:
-// CHECK-NEXT: mrs r3, EPSR
+// CHECK-NEXT: mrs r0, EPSR
 // CHECK-EMPTY:
 
 // Test getIepsrReg()
-extern "C" [[gnu::naked]] void test_get_iepsr() {
-    ArmCortex::PSR iepsr = ArmCortex::getIepsrReg();
-    (void)iepsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_iepsr() {
+    return ArmCortex::getIepsrReg();
 }
 
 // CHECK-LABEL: <test_get_iepsr>:
-// CHECK-NEXT: mrs r3, IEPSR
+// CHECK-NEXT: mrs r0, IEPSR
 // CHECK-EMPTY:
 
 // Test getIapsrReg()
-extern "C" [[gnu::naked]] void test_get_iapsr() {
-    ArmCortex::PSR iapsr = ArmCortex::getIapsrReg();
-    (void)iapsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_iapsr() {
+    return ArmCortex::getIapsrReg();
 }
 
 // CHECK-LABEL: <test_get_iapsr>:
-// CHECK-NEXT: mrs r3, IAPSR
+// CHECK-NEXT: mrs r0, IAPSR
 // CHECK-EMPTY:
 
 // Test getEapsrReg()
-extern "C" [[gnu::naked]] void test_get_eapsr() {
-    ArmCortex::PSR eapsr = ArmCortex::getEapsrReg();
-    (void)eapsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_eapsr() {
+    return ArmCortex::getEapsrReg();
 }
 
 // CHECK-LABEL: <test_get_eapsr>:
-// CHECK-NEXT: mrs r3, EAPSR
+// CHECK-NEXT: mrs r0, EAPSR
 // CHECK-EMPTY:
 
 // Test getPsrReg()
-extern "C" [[gnu::naked]] void test_get_psr() {
-    ArmCortex::PSR psr = ArmCortex::getPsrReg();
-    (void)psr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_psr() {
+    return ArmCortex::getPsrReg();
 }
 
 // CHECK-LABEL: <test_get_psr>:
-// CHECK-NEXT: mrs r3, PSR
+// CHECK-NEXT: mrs r0, PSR
 // CHECK-EMPTY:
 
 // Test getMspReg()
-extern "C" [[gnu::naked]] void test_get_msp() {
-    uint32_t msp = ArmCortex::getMspReg();
-    (void)msp;
+extern "C" [[gnu::naked]] uint32_t test_get_msp() {
+    return ArmCortex::getMspReg();
 }
 
 // CHECK-LABEL: <test_get_msp>:
-// CHECK-NEXT: mrs r3, MSP
+// CHECK-NEXT: mrs r0, MSP
 // CHECK-EMPTY:
 
 // Test setMspReg()
@@ -97,20 +94,29 @@ extern "C" [[gnu::naked]] void test_set_msp() {
 }
 
 // CHECK-LABEL: <test_set_msp>:
-// CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: msr MSP, r3
+
+// DEBUG-CHECK-NEXT: ldr r3, [pc, #4]
+// DEBUG-CHECK-NEXT: msr MSP, r3
+// DEBUG-CHECK-NEXT: .word 0x20001000
+
+// MINSIZE-CHECK-NEXT: ldr r3, [pc, #4]
+// MINSIZE-CHECK-NEXT: msr MSP, r3
+// MINSIZE-CHECK-NEXT: .word 0x20001000
+
+// MAXSPEED-CHECK-NEXT: ldr r3, [pc, #4]
+// MAXSPEED-CHECK-NEXT: msr MSP, r3
 // MAXSPEED-CHECK-NEXT: nop
-// CHECK-NEXT: .word 0x20001000
+// MAXSPEED-CHECK-NEXT: .word 0x20001000
+
 // CHECK-EMPTY:
 
 // Test getPspReg()
-extern "C" [[gnu::naked]] void test_get_psp() {
-    uint32_t psp = ArmCortex::getPspReg();
-    (void)psp;
+extern "C" [[gnu::naked]] uint32_t test_get_psp() {
+    return ArmCortex::getPspReg();
 }
 
 // CHECK-LABEL: <test_get_psp>:
-// CHECK-NEXT: mrs r3, PSP
+// CHECK-NEXT: mrs r0, PSP
 // CHECK-EMPTY:
 
 // Test setPspReg()
@@ -119,20 +125,31 @@ extern "C" [[gnu::naked]] void test_set_psp() {
 }
 
 // CHECK-LABEL: <test_set_psp>:
-// CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: msr PSP, r3
-// CHECK-NEXT: nop
-// CHECK-NEXT: .word 0x20002000
+
+// DEBUG-CHECK-NEXT: ldr r3, [pc, #4]
+// DEBUG-CHECK-NEXT: msr PSP, r3
+// DEBUG-CHECK-NEXT: nop
+// DEBUG-CHECK-NEXT: .word 0x20002000
+
+// MINSIZE-CHECK-NEXT: ldr r3, [pc, #4]
+// MINSIZE-CHECK-NEXT: msr PSP, r3
+// MINSIZE-CHECK-NEXT: nop
+// MINSIZE-CHECK-NEXT: .word 0x20002000
+
+// MAXSPEED-CHECK-NEXT: ldr r3, [pc, #4]
+// MAXSPEED-CHECK-NEXT: msr PSP, r3
+// MAXSPEED-CHECK-NEXT: nop
+// MAXSPEED-CHECK-NEXT: .word 0x20002000
+
 // CHECK-EMPTY:
 
 // Test getPrimaskReg()
-extern "C" [[gnu::naked]] void test_get_primask() {
-    ArmCortex::PRIMASK primask = ArmCortex::getPrimaskReg();
-    (void)primask;
+extern "C" [[gnu::naked]] ArmCortex::PRIMASK test_get_primask() {
+    return ArmCortex::getPrimaskReg();
 }
 
 // CHECK-LABEL: <test_get_primask>:
-// CHECK-NEXT: mrs r3, PRIMASK
+// CHECK-NEXT: mrs r0, PRIMASK
 // CHECK-EMPTY:
 
 // Test setPrimaskReg()
@@ -143,19 +160,26 @@ extern "C" [[gnu::naked]] void test_set_primask() {
 }
 
 // CHECK-LABEL: <test_set_primask>:
-// CHECK-NEXT: movs r3, #1
-// CHECK-NEXT: msr PRIMASK, r3
+
+// DEBUG-CHECK-NEXT: movs r3, #1
+// DEBUG-CHECK-NEXT: msr PRIMASK, r3
+
+// MINSIZE-CHECK-NEXT: movs r3, #1
+// MINSIZE-CHECK-NEXT: msr PRIMASK, r3
+
+// MAXSPEED-CHECK-NEXT: movs r3, #1
+// MAXSPEED-CHECK-NEXT: msr PRIMASK, r3
 // MAXSPEED-CHECK-NEXT: nop
+
 // CHECK-EMPTY:
 
 // Test getControlReg()
-extern "C" [[gnu::naked]] void test_get_control() {
-    ArmCortex::CONTROL control = ArmCortex::getControlReg();
-    (void)control;
+extern "C" [[gnu::naked]] ArmCortex::CONTROL test_get_control() {
+    return ArmCortex::getControlReg();
 }
 
 // CHECK-LABEL: <test_get_control>:
-// CHECK-NEXT: mrs r3, CONTROL
+// CHECK-NEXT: mrs r0, CONTROL
 // CHECK-EMPTY:
 
 // Test setControlReg()
@@ -166,7 +190,15 @@ extern "C" [[gnu::naked]] void test_set_control() {
 }
 
 // CHECK-LABEL: <test_set_control>:
-// CHECK-NEXT: movs r3, #2
-// CHECK-NEXT: msr CONTROL, r3
+
+// DEBUG-CHECK-NEXT: movs r3, #2
+// DEBUG-CHECK-NEXT: msr CONTROL, r3
+
+// MINSIZE-CHECK-NEXT: movs r3, #2
+// MINSIZE-CHECK-NEXT: msr CONTROL, r3
+
+// MAXSPEED-CHECK-NEXT: movs r3, #2
+// MAXSPEED-CHECK-NEXT: msr CONTROL, r3
 // MAXSPEED-CHECK-NEXT: nop
+
 // CHECK-EMPTY:

--- a/tests/m3/test_mpu.cpp
+++ b/tests/m3/test_mpu.cpp
@@ -1,9 +1,8 @@
 #include "armcortex/m3/mpu.hpp"
 
 // Test reading TYPE register
-extern "C" [[gnu::naked]] void test_read_type() {
-    auto type = ArmCortex::Mpu::TYPE(ArmCortex::MPU->TYPE);
-    (void)type;
+extern "C" [[gnu::naked]] auto test_read_type() {
+    return ArmCortex::Mpu::TYPE(ArmCortex::MPU->TYPE);
 }
 
 // CHECK-LABEL: <test_read_type>:
@@ -14,9 +13,8 @@ extern "C" [[gnu::naked]] void test_read_type() {
 // CHECK-EMPTY:
 
 // Test reading CTRL register
-extern "C" [[gnu::naked]] void test_read_ctrl() {
-    auto ctrl = ArmCortex::Mpu::CTRL(ArmCortex::MPU->CTRL);
-    (void)ctrl;
+extern "C" [[gnu::naked]] auto test_read_ctrl() {
+    return ArmCortex::Mpu::CTRL(ArmCortex::MPU->CTRL);
 }
 
 // CHECK-LABEL: <test_read_ctrl>:
@@ -54,9 +52,8 @@ extern "C" [[gnu::naked]] void test_write_ctrl() {
 // CHECK-EMPTY:
 
 // Test reading RNR register
-extern "C" [[gnu::naked]] void test_read_rnr() {
-    uint32_t rnr = ArmCortex::MPU->RNR;
-    (void)rnr;
+extern "C" [[gnu::naked]] uint32_t test_read_rnr() {
+    return ArmCortex::MPU->RNR;
 }
 
 // CHECK-LABEL: <test_read_rnr>:
@@ -91,9 +88,8 @@ extern "C" [[gnu::naked]] void test_write_rnr() {
 // CHECK-EMPTY:
 
 // Test reading RBAR register
-extern "C" [[gnu::naked]] void test_read_rbar() {
-    auto rbar = ArmCortex::Mpu::RBAR(ArmCortex::MPU->RBAR);
-    (void)rbar;
+extern "C" [[gnu::naked]] auto test_read_rbar() {
+    return ArmCortex::Mpu::RBAR(ArmCortex::MPU->RBAR);
 }
 
 // CHECK-LABEL: <test_read_rbar>:
@@ -137,9 +133,8 @@ extern "C" [[gnu::naked]] void test_write_rbar() {
 // CHECK-EMPTY:
 
 // Test reading RASR register
-extern "C" [[gnu::naked]] void test_read_rasr() {
-    auto rasr = ArmCortex::Mpu::RASR(ArmCortex::MPU->RASR);
-    (void)rasr;
+extern "C" [[gnu::naked]] auto test_read_rasr() {
+    return ArmCortex::Mpu::RASR(ArmCortex::MPU->RASR);
 }
 
 // CHECK-LABEL: <test_read_rasr>:
@@ -188,9 +183,8 @@ extern "C" [[gnu::naked]] void test_write_rasr() {
 // ============================================================================
 
 // Test reading RBAR_A1 register
-extern "C" [[gnu::naked]] void test_read_rbar_a1() {
-    uint32_t rbar_a1 = ArmCortex::MPU->RBAR_A1;
-    (void)rbar_a1;
+extern "C" [[gnu::naked]] uint32_t test_read_rbar_a1() {
+    return ArmCortex::MPU->RBAR_A1;
 }
 
 // CHECK-LABEL: <test_read_rbar_a1>:
@@ -226,9 +220,8 @@ extern "C" [[gnu::naked]] void test_write_rbar_a1() {
 // CHECK-EMPTY:
 
 // Test reading RASR_A1 register
-extern "C" [[gnu::naked]] void test_read_rasr_a1() {
-    uint32_t rasr_a1 = ArmCortex::MPU->RASR_A1;
-    (void)rasr_a1;
+extern "C" [[gnu::naked]] uint32_t test_read_rasr_a1() {
+    return ArmCortex::MPU->RASR_A1;
 }
 
 // CHECK-LABEL: <test_read_rasr_a1>:
@@ -273,9 +266,8 @@ extern "C" [[gnu::naked]] void test_write_rasr_a1() {
 // CHECK-EMPTY:
 
 // Test reading RBAR_A2 register
-extern "C" [[gnu::naked]] void test_read_rbar_a2() {
-    uint32_t rbar_a2 = ArmCortex::MPU->RBAR_A2;
-    (void)rbar_a2;
+extern "C" [[gnu::naked]] uint32_t test_read_rbar_a2() {
+    return ArmCortex::MPU->RBAR_A2;
 }
 
 // CHECK-LABEL: <test_read_rbar_a2>:
@@ -319,9 +311,8 @@ extern "C" [[gnu::naked]] void test_write_rbar_a2() {
 // CHECK-EMPTY:
 
 // Test reading RASR_A2 register
-extern "C" [[gnu::naked]] void test_read_rasr_a2() {
-    uint32_t rasr_a2 = ArmCortex::MPU->RASR_A2;
-    (void)rasr_a2;
+extern "C" [[gnu::naked]] uint32_t test_read_rasr_a2() {
+    return ArmCortex::MPU->RASR_A2;
 }
 
 // CHECK-LABEL: <test_read_rasr_a2>:
@@ -366,9 +357,8 @@ extern "C" [[gnu::naked]] void test_write_rasr_a2() {
 // CHECK-EMPTY:
 
 // Test reading RBAR_A3 register
-extern "C" [[gnu::naked]] void test_read_rbar_a3() {
-    uint32_t rbar_a3 = ArmCortex::MPU->RBAR_A3;
-    (void)rbar_a3;
+extern "C" [[gnu::naked]] uint32_t test_read_rbar_a3() {
+    return ArmCortex::MPU->RBAR_A3;
 }
 
 // CHECK-LABEL: <test_read_rbar_a3>:
@@ -412,9 +402,8 @@ extern "C" [[gnu::naked]] void test_write_rbar_a3() {
 // CHECK-EMPTY:
 
 // Test reading RASR_A3 register
-extern "C" [[gnu::naked]] void test_read_rasr_a3() {
-    uint32_t rasr_a3 = ArmCortex::MPU->RASR_A3;
-    (void)rasr_a3;
+extern "C" [[gnu::naked]] uint32_t test_read_rasr_a3() {
+    return ArmCortex::MPU->RASR_A3;
 }
 
 // CHECK-LABEL: <test_read_rasr_a3>:

--- a/tests/m3/test_mpu.cpp
+++ b/tests/m3/test_mpu.cpp
@@ -7,7 +7,7 @@ extern "C" [[gnu::naked]] auto test_read_type() {
 
 // CHECK-LABEL: <test_read_type>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #144]
+// CHECK-NEXT: ldr.w r0, [r3, #144]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -19,7 +19,7 @@ extern "C" [[gnu::naked]] auto test_read_ctrl() {
 
 // CHECK-LABEL: <test_read_ctrl>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #148]
+// CHECK-NEXT: ldr.w r0, [r3, #148]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -58,7 +58,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_rnr() {
 
 // CHECK-LABEL: <test_read_rnr>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #152]
+// CHECK-NEXT: ldr.w r0, [r3, #152]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -94,7 +94,7 @@ extern "C" [[gnu::naked]] auto test_read_rbar() {
 
 // CHECK-LABEL: <test_read_rbar>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #156]
+// CHECK-NEXT: ldr.w r0, [r3, #156]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -139,7 +139,7 @@ extern "C" [[gnu::naked]] auto test_read_rasr() {
 
 // CHECK-LABEL: <test_read_rasr>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #160]
+// CHECK-NEXT: ldr.w r0, [r3, #160]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -189,7 +189,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_rbar_a1() {
 
 // CHECK-LABEL: <test_read_rbar_a1>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #164]
+// CHECK-NEXT: ldr.w r0, [r3, #164]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -226,7 +226,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_rasr_a1() {
 
 // CHECK-LABEL: <test_read_rasr_a1>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #168]
+// CHECK-NEXT: ldr.w r0, [r3, #168]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -272,7 +272,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_rbar_a2() {
 
 // CHECK-LABEL: <test_read_rbar_a2>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #172]
+// CHECK-NEXT: ldr.w r0, [r3, #172]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -317,7 +317,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_rasr_a2() {
 
 // CHECK-LABEL: <test_read_rasr_a2>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #176]
+// CHECK-NEXT: ldr.w r0, [r3, #176]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -363,7 +363,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_rbar_a3() {
 
 // CHECK-LABEL: <test_read_rbar_a3>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #180]
+// CHECK-NEXT: ldr.w r0, [r3, #180]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -408,7 +408,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_rasr_a3() {
 
 // CHECK-LABEL: <test_read_rasr_a3>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #184]
+// CHECK-NEXT: ldr.w r0, [r3, #184]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:

--- a/tests/m3/test_nvic.cpp
+++ b/tests/m3/test_nvic.cpp
@@ -6,8 +6,9 @@ extern "C" [[gnu::naked]] bool test_is_irq_enabled() {
 }
 
 // CHECK-LABEL: <test_is_irq_enabled>:
-// CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #0]
+// CHECK-NEXT: ldr r3, [pc, #4]
+// CHECK-NEXT: ldr r0, [r3, #0]
+// CHECK-NEXT: ubfx r0, r0, #5, #1
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-EMPTY:
 
@@ -17,8 +18,9 @@ extern "C" [[gnu::naked]] bool test_is_irq_enabled_high() {
 }
 
 // CHECK-LABEL: <test_is_irq_enabled_high>:
-// CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #4]
+// CHECK-NEXT: ldr r3, [pc, #4]
+// CHECK-NEXT: ldr r0, [r3, #4]
+// CHECK-NEXT: ubfx r0, r0, #13, #1
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-EMPTY:
 
@@ -127,8 +129,9 @@ extern "C" [[gnu::naked]] bool test_is_irq_pending() {
 }
 
 // CHECK-LABEL: <test_is_irq_pending>:
-// CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #256]
+// CHECK-NEXT: ldr r3, [pc, #8]
+// CHECK-NEXT: ldr.w r0, [r3, #256]
+// CHECK-NEXT: ubfx r0, r0, #3, #1
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-EMPTY:
@@ -193,8 +196,9 @@ extern "C" [[gnu::naked]] bool test_is_irq_active() {
 }
 
 // CHECK-LABEL: <test_is_irq_active>:
-// CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldr.w r3, [r3, #512]
+// CHECK-NEXT: ldr r3, [pc, #8]
+// CHECK-NEXT: ldr.w r0, [r3, #512]
+// CHECK-NEXT: ubfx r0, r0, #8, #1
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-EMPTY:
@@ -206,7 +210,7 @@ extern "C" [[gnu::naked]] uint8_t test_read_ipr() {
 
 // CHECK-LABEL: <test_read_ipr>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldrb.w r3, [r3, #773]
+// CHECK-NEXT: ldrb.w r0, [r3, #773]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000e100
 // CHECK-EMPTY:

--- a/tests/m3/test_nvic.cpp
+++ b/tests/m3/test_nvic.cpp
@@ -1,9 +1,8 @@
 #include "armcortex/m3/nvic.hpp"
 
 // Test isIrqEnabled() - IRQ in first register
-extern "C" [[gnu::naked]] void test_is_irq_enabled() {
-    bool enabled = ArmCortex::Nvic::isIrqEnabled(5);
-    (void)enabled;
+extern "C" [[gnu::naked]] bool test_is_irq_enabled() {
+    return ArmCortex::Nvic::isIrqEnabled(5);
 }
 
 // CHECK-LABEL: <test_is_irq_enabled>:
@@ -13,9 +12,8 @@ extern "C" [[gnu::naked]] void test_is_irq_enabled() {
 // CHECK-EMPTY:
 
 // Test isIrqEnabled() - IRQ in second register (tests array indexing)
-extern "C" [[gnu::naked]] void test_is_irq_enabled_high() {
-    bool enabled = ArmCortex::Nvic::isIrqEnabled(45);
-    (void)enabled;
+extern "C" [[gnu::naked]] bool test_is_irq_enabled_high() {
+    return ArmCortex::Nvic::isIrqEnabled(45);
 }
 
 // CHECK-LABEL: <test_is_irq_enabled_high>:
@@ -124,9 +122,8 @@ extern "C" [[gnu::naked]] void test_disable_irq_high() {
 // CHECK-EMPTY:
 
 // Test isIrqPending()
-extern "C" [[gnu::naked]] void test_is_irq_pending() {
-    bool pending = ArmCortex::Nvic::isIrqPending(3);
-    (void)pending;
+extern "C" [[gnu::naked]] bool test_is_irq_pending() {
+    return ArmCortex::Nvic::isIrqPending(3);
 }
 
 // CHECK-LABEL: <test_is_irq_pending>:
@@ -191,9 +188,8 @@ extern "C" [[gnu::naked]] void test_clear_pending_irq() {
 // CHECK-EMPTY:
 
 // Test isIrqActive() - M3-specific
-extern "C" [[gnu::naked]] void test_is_irq_active() {
-    bool active = ArmCortex::Nvic::isIrqActive(8);
-    (void)active;
+extern "C" [[gnu::naked]] bool test_is_irq_active() {
+    return ArmCortex::Nvic::isIrqActive(8);
 }
 
 // CHECK-LABEL: <test_is_irq_active>:
@@ -204,9 +200,8 @@ extern "C" [[gnu::naked]] void test_is_irq_active() {
 // CHECK-EMPTY:
 
 // Test reading IPR (interrupt priority)
-extern "C" [[gnu::naked]] void test_read_ipr() {
-    uint8_t priority = ArmCortex::NVIC->IPR[5];
-    (void)priority;
+extern "C" [[gnu::naked]] uint8_t test_read_ipr() {
+    return ArmCortex::NVIC->IPR[5];
 }
 
 // CHECK-LABEL: <test_read_ipr>:

--- a/tests/m3/test_scb.cpp
+++ b/tests/m3/test_scb.cpp
@@ -5,9 +5,8 @@
 // =============================================================================
 
 // Test reading CPUID register (offset 0x00)
-extern "C" [[gnu::naked]] void test_read_cpuid() {
-    auto cpuid = ArmCortex::Scb::CPUID(ArmCortex::SCB->CPUID);
-    (void)cpuid;
+extern "C" [[gnu::naked]] auto test_read_cpuid() {
+    return ArmCortex::Scb::CPUID(ArmCortex::SCB->CPUID);
 }
 
 // CHECK-LABEL: <test_read_cpuid>:
@@ -17,9 +16,8 @@ extern "C" [[gnu::naked]] void test_read_cpuid() {
 // CHECK-EMPTY:
 
 // Test reading ICSR register (offset 0x04)
-extern "C" [[gnu::naked]] void test_read_icsr() {
-    auto icsr = ArmCortex::Scb::ICSR(ArmCortex::SCB->ICSR);
-    (void)icsr;
+extern "C" [[gnu::naked]] auto test_read_icsr() {
+    return ArmCortex::Scb::ICSR(ArmCortex::SCB->ICSR);
 }
 
 // CHECK-LABEL: <test_read_icsr>:
@@ -55,9 +53,8 @@ extern "C" [[gnu::naked]] void test_write_icsr() {
 // CHECK-EMPTY:
 
 // Test reading VTOR register (offset 0x08)
-extern "C" [[gnu::naked]] void test_read_vtor() {
-    uint32_t vtor = ArmCortex::SCB->VTOR;
-    (void)vtor;
+extern "C" [[gnu::naked]] uint32_t test_read_vtor() {
+    return ArmCortex::SCB->VTOR;
 }
 
 // CHECK-LABEL: <test_read_vtor>:
@@ -91,9 +88,8 @@ extern "C" [[gnu::naked]] void test_write_vtor() {
 // CHECK-EMPTY:
 
 // Test reading AIRCR register (offset 0x0C)
-extern "C" [[gnu::naked]] void test_read_aircr() {
-    auto aircr = ArmCortex::Scb::AIRCR(ArmCortex::SCB->AIRCR);
-    (void)aircr;
+extern "C" [[gnu::naked]] auto test_read_aircr() {
+    return ArmCortex::Scb::AIRCR(ArmCortex::SCB->AIRCR);
 }
 
 // CHECK-LABEL: <test_read_aircr>:
@@ -120,9 +116,8 @@ extern "C" [[gnu::naked]] void test_write_aircr() {
 // CHECK-EMPTY:
 
 // Test reading SCR register (offset 0x10)
-extern "C" [[gnu::naked]] void test_read_scr() {
-    auto scr = ArmCortex::Scb::SCR(ArmCortex::SCB->SCR);
-    (void)scr;
+extern "C" [[gnu::naked]] auto test_read_scr() {
+    return ArmCortex::Scb::SCR(ArmCortex::SCB->SCR);
 }
 
 // CHECK-LABEL: <test_read_scr>:
@@ -161,9 +156,8 @@ extern "C" [[gnu::naked]] void test_write_scr() {
 // CHECK-EMPTY:
 
 // Test reading CCR register (offset 0x14)
-extern "C" [[gnu::naked]] void test_read_ccr() {
-    auto ccr = ArmCortex::Scb::CCR(ArmCortex::SCB->CCR);
-    (void)ccr;
+extern "C" [[gnu::naked]] auto test_read_ccr() {
+    return ArmCortex::Scb::CCR(ArmCortex::SCB->CCR);
 }
 
 // CHECK-LABEL: <test_read_ccr>:
@@ -204,9 +198,8 @@ extern "C" [[gnu::naked]] void test_write_ccr() {
 // =============================================================================
 
 // Test reading SHPR[0] (offset 0x18) - MemManage priority
-extern "C" [[gnu::naked]] void test_read_shpr0() {
-    uint8_t pri = ArmCortex::SCB->SHPR[0];
-    (void)pri;
+extern "C" [[gnu::naked]] uint8_t test_read_shpr0() {
+    return ArmCortex::SCB->SHPR[0];
 }
 
 // CHECK-LABEL: <test_read_shpr0>:
@@ -243,9 +236,8 @@ extern "C" [[gnu::naked]] void test_write_shpr0() {
 // CHECK-EMPTY:
 
 // Test reading SHPR[7] (offset 0x1F) - SVCall priority
-extern "C" [[gnu::naked]] void test_read_shpr7() {
-    uint8_t pri = ArmCortex::SCB->SHPR[7];
-    (void)pri;
+extern "C" [[gnu::naked]] uint8_t test_read_shpr7() {
+    return ArmCortex::SCB->SHPR[7];
 }
 
 // CHECK-LABEL: <test_read_shpr7>:
@@ -255,9 +247,8 @@ extern "C" [[gnu::naked]] void test_read_shpr7() {
 // CHECK-EMPTY:
 
 // Test reading SHPR[10] (offset 0x22) - PendSV priority
-extern "C" [[gnu::naked]] void test_read_shpr10() {
-    uint8_t pri = ArmCortex::SCB->SHPR[10];
-    (void)pri;
+extern "C" [[gnu::naked]] uint8_t test_read_shpr10() {
+    return ArmCortex::SCB->SHPR[10];
 }
 
 // CHECK-LABEL: <test_read_shpr10>:
@@ -268,9 +259,8 @@ extern "C" [[gnu::naked]] void test_read_shpr10() {
 // CHECK-EMPTY:
 
 // Test reading SHPR[11] (offset 0x23) - SysTick priority
-extern "C" [[gnu::naked]] void test_read_shpr11() {
-    uint8_t pri = ArmCortex::SCB->SHPR[11];
-    (void)pri;
+extern "C" [[gnu::naked]] uint8_t test_read_shpr11() {
+    return ArmCortex::SCB->SHPR[11];
 }
 
 // CHECK-LABEL: <test_read_shpr11>:
@@ -309,9 +299,8 @@ extern "C" [[gnu::naked]] void test_write_shpr11() {
 // =============================================================================
 
 // Test reading SHCSR register (offset 0x24)
-extern "C" [[gnu::naked]] void test_read_shcsr() {
-    auto shcsr = ArmCortex::Scb::SHCSR(ArmCortex::SCB->SHCSR);
-    (void)shcsr;
+extern "C" [[gnu::naked]] auto test_read_shcsr() {
+    return ArmCortex::Scb::SHCSR(ArmCortex::SCB->SHCSR);
 }
 
 // CHECK-LABEL: <test_read_shcsr>:
@@ -353,9 +342,8 @@ extern "C" [[gnu::naked]] void test_write_shcsr() {
 // =============================================================================
 
 // Test reading CFSR register (offset 0x28)
-extern "C" [[gnu::naked]] void test_read_cfsr() {
-    auto cfsr = ArmCortex::Scb::CFSR(ArmCortex::SCB->CFSR);
-    (void)cfsr;
+extern "C" [[gnu::naked]] auto test_read_cfsr() {
+    return ArmCortex::Scb::CFSR(ArmCortex::SCB->CFSR);
 }
 
 // CHECK-LABEL: <test_read_cfsr>:
@@ -391,9 +379,8 @@ extern "C" [[gnu::naked]] void test_write_cfsr() {
 // CHECK-EMPTY:
 
 // Test reading HFSR register (offset 0x2C)
-extern "C" [[gnu::naked]] void test_read_hfsr() {
-    auto hfsr = ArmCortex::Scb::HFSR(ArmCortex::SCB->HFSR);
-    (void)hfsr;
+extern "C" [[gnu::naked]] auto test_read_hfsr() {
+    return ArmCortex::Scb::HFSR(ArmCortex::SCB->HFSR);
 }
 
 // CHECK-LABEL: <test_read_hfsr>:
@@ -429,9 +416,8 @@ extern "C" [[gnu::naked]] void test_write_hfsr() {
 // CHECK-EMPTY:
 
 // Test reading DFSR register (offset 0x30)
-extern "C" [[gnu::naked]] void test_read_dfsr() {
-    auto dfsr = ArmCortex::Scb::DFSR(ArmCortex::SCB->DFSR);
-    (void)dfsr;
+extern "C" [[gnu::naked]] auto test_read_dfsr() {
+    return ArmCortex::Scb::DFSR(ArmCortex::SCB->DFSR);
 }
 
 // CHECK-LABEL: <test_read_dfsr>:
@@ -445,9 +431,8 @@ extern "C" [[gnu::naked]] void test_read_dfsr() {
 // =============================================================================
 
 // Test reading MMFAR register (offset 0x34)
-extern "C" [[gnu::naked]] void test_read_mmfar() {
-    uint32_t mmfar = ArmCortex::SCB->MMFAR;
-    (void)mmfar;
+extern "C" [[gnu::naked]] uint32_t test_read_mmfar() {
+    return ArmCortex::SCB->MMFAR;
 }
 
 // CHECK-LABEL: <test_read_mmfar>:
@@ -457,9 +442,8 @@ extern "C" [[gnu::naked]] void test_read_mmfar() {
 // CHECK-EMPTY:
 
 // Test reading BFAR register (offset 0x38)
-extern "C" [[gnu::naked]] void test_read_bfar() {
-    uint32_t bfar = ArmCortex::SCB->BFAR;
-    (void)bfar;
+extern "C" [[gnu::naked]] uint32_t test_read_bfar() {
+    return ArmCortex::SCB->BFAR;
 }
 
 // CHECK-LABEL: <test_read_bfar>:
@@ -469,9 +453,8 @@ extern "C" [[gnu::naked]] void test_read_bfar() {
 // CHECK-EMPTY:
 
 // Test reading AFSR register (offset 0x3C)
-extern "C" [[gnu::naked]] void test_read_afsr() {
-    uint32_t afsr = ArmCortex::SCB->AFSR;
-    (void)afsr;
+extern "C" [[gnu::naked]] uint32_t test_read_afsr() {
+    return ArmCortex::SCB->AFSR;
 }
 
 // CHECK-LABEL: <test_read_afsr>:

--- a/tests/m3/test_scb.cpp
+++ b/tests/m3/test_scb.cpp
@@ -11,7 +11,7 @@ extern "C" [[gnu::naked]] auto test_read_cpuid() {
 
 // CHECK-LABEL: <test_read_cpuid>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #0]
+// CHECK-NEXT: ldr r0, [r3, #0]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -22,7 +22,7 @@ extern "C" [[gnu::naked]] auto test_read_icsr() {
 
 // CHECK-LABEL: <test_read_icsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #4]
+// CHECK-NEXT: ldr r0, [r3, #4]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -59,7 +59,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_vtor() {
 
 // CHECK-LABEL: <test_read_vtor>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #8]
+// CHECK-NEXT: ldr r0, [r3, #8]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -94,7 +94,7 @@ extern "C" [[gnu::naked]] auto test_read_aircr() {
 
 // CHECK-LABEL: <test_read_aircr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #12]
+// CHECK-NEXT: ldr r0, [r3, #12]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -122,7 +122,7 @@ extern "C" [[gnu::naked]] auto test_read_scr() {
 
 // CHECK-LABEL: <test_read_scr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #16]
+// CHECK-NEXT: ldr r0, [r3, #16]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -162,7 +162,7 @@ extern "C" [[gnu::naked]] auto test_read_ccr() {
 
 // CHECK-LABEL: <test_read_ccr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #20]
+// CHECK-NEXT: ldr r0, [r3, #20]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -204,7 +204,7 @@ extern "C" [[gnu::naked]] uint8_t test_read_shpr0() {
 
 // CHECK-LABEL: <test_read_shpr0>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldrb r3, [r3, #24]
+// CHECK-NEXT: ldrb r0, [r3, #24]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -242,7 +242,7 @@ extern "C" [[gnu::naked]] uint8_t test_read_shpr7() {
 
 // CHECK-LABEL: <test_read_shpr7>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldrb r3, [r3, #31]
+// CHECK-NEXT: ldrb r0, [r3, #31]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -253,7 +253,7 @@ extern "C" [[gnu::naked]] uint8_t test_read_shpr10() {
 
 // CHECK-LABEL: <test_read_shpr10>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldrb.w r3, [r3, #34]
+// CHECK-NEXT: ldrb.w r0, [r3, #34]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -265,7 +265,7 @@ extern "C" [[gnu::naked]] uint8_t test_read_shpr11() {
 
 // CHECK-LABEL: <test_read_shpr11>:
 // CHECK-NEXT: ldr r3, [pc, #4]
-// CHECK-NEXT: ldrb.w r3, [r3, #35]
+// CHECK-NEXT: ldrb.w r0, [r3, #35]
 // CHECK-NEXT: nop
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
@@ -305,7 +305,7 @@ extern "C" [[gnu::naked]] auto test_read_shcsr() {
 
 // CHECK-LABEL: <test_read_shcsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #36]
+// CHECK-NEXT: ldr r0, [r3, #36]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -348,7 +348,7 @@ extern "C" [[gnu::naked]] auto test_read_cfsr() {
 
 // CHECK-LABEL: <test_read_cfsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #40]
+// CHECK-NEXT: ldr r0, [r3, #40]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -385,7 +385,7 @@ extern "C" [[gnu::naked]] auto test_read_hfsr() {
 
 // CHECK-LABEL: <test_read_hfsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #44]
+// CHECK-NEXT: ldr r0, [r3, #44]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -422,7 +422,7 @@ extern "C" [[gnu::naked]] auto test_read_dfsr() {
 
 // CHECK-LABEL: <test_read_dfsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #48]
+// CHECK-NEXT: ldr r0, [r3, #48]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -437,7 +437,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_mmfar() {
 
 // CHECK-LABEL: <test_read_mmfar>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #52]
+// CHECK-NEXT: ldr r0, [r3, #52]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -448,7 +448,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_bfar() {
 
 // CHECK-LABEL: <test_read_bfar>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #56]
+// CHECK-NEXT: ldr r0, [r3, #56]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 
@@ -459,7 +459,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_afsr() {
 
 // CHECK-LABEL: <test_read_afsr>:
 // CHECK-NEXT: ldr r3, [pc, #0]
-// CHECK-NEXT: ldr r3, [r3, #60]
+// CHECK-NEXT: ldr r0, [r3, #60]
 // CHECK-NEXT: .word 0xe000ed00
 // CHECK-EMPTY:
 

--- a/tests/m3/test_special_regs.cpp
+++ b/tests/m3/test_special_regs.cpp
@@ -1,9 +1,8 @@
 #include "armcortex/m3/special_regs.hpp"
 
 // Test getLr()
-extern "C" [[gnu::naked]] void test_get_lr() {
-    uint32_t lr = ArmCortex::getLr();
-    (void)lr;
+extern "C" [[gnu::naked]] uint32_t test_get_lr() {
+    return ArmCortex::getLr();
 }
 
 // CHECK-LABEL: <test_get_lr>:
@@ -12,9 +11,8 @@ extern "C" [[gnu::naked]] void test_get_lr() {
 // CHECK-EMPTY:
 
 // Test getApsrReg()
-extern "C" [[gnu::naked]] void test_get_apsr() {
-    ArmCortex::PSR apsr = ArmCortex::getApsrReg();
-    (void)apsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_apsr() {
+    return ArmCortex::getApsrReg();
 }
 
 // CHECK-LABEL: <test_get_apsr>:
@@ -22,9 +20,8 @@ extern "C" [[gnu::naked]] void test_get_apsr() {
 // CHECK-EMPTY:
 
 // Test getIpsrReg()
-extern "C" [[gnu::naked]] void test_get_ipsr() {
-    ArmCortex::PSR ipsr = ArmCortex::getIpsrReg();
-    (void)ipsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_ipsr() {
+    return ArmCortex::getIpsrReg();
 }
 
 // CHECK-LABEL: <test_get_ipsr>:
@@ -32,9 +29,8 @@ extern "C" [[gnu::naked]] void test_get_ipsr() {
 // CHECK-EMPTY:
 
 // Test getEpsrReg()
-extern "C" [[gnu::naked]] void test_get_epsr() {
-    ArmCortex::PSR epsr = ArmCortex::getEpsrReg();
-    (void)epsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_epsr() {
+    return ArmCortex::getEpsrReg();
 }
 
 // CHECK-LABEL: <test_get_epsr>:
@@ -42,9 +38,8 @@ extern "C" [[gnu::naked]] void test_get_epsr() {
 // CHECK-EMPTY:
 
 // Test getIepsrReg()
-extern "C" [[gnu::naked]] void test_get_iepsr() {
-    ArmCortex::PSR iepsr = ArmCortex::getIepsrReg();
-    (void)iepsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_iepsr() {
+    return ArmCortex::getIepsrReg();
 }
 
 // CHECK-LABEL: <test_get_iepsr>:
@@ -52,9 +47,8 @@ extern "C" [[gnu::naked]] void test_get_iepsr() {
 // CHECK-EMPTY:
 
 // Test getIapsrReg()
-extern "C" [[gnu::naked]] void test_get_iapsr() {
-    ArmCortex::PSR iapsr = ArmCortex::getIapsrReg();
-    (void)iapsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_iapsr() {
+    return ArmCortex::getIapsrReg();
 }
 
 // CHECK-LABEL: <test_get_iapsr>:
@@ -62,9 +56,8 @@ extern "C" [[gnu::naked]] void test_get_iapsr() {
 // CHECK-EMPTY:
 
 // Test getEapsrReg()
-extern "C" [[gnu::naked]] void test_get_eapsr() {
-    ArmCortex::PSR eapsr = ArmCortex::getEapsrReg();
-    (void)eapsr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_eapsr() {
+    return ArmCortex::getEapsrReg();
 }
 
 // CHECK-LABEL: <test_get_eapsr>:
@@ -72,9 +65,8 @@ extern "C" [[gnu::naked]] void test_get_eapsr() {
 // CHECK-EMPTY:
 
 // Test getPsrReg()
-extern "C" [[gnu::naked]] void test_get_psr() {
-    ArmCortex::PSR psr = ArmCortex::getPsrReg();
-    (void)psr;
+extern "C" [[gnu::naked]] ArmCortex::PSR test_get_psr() {
+    return ArmCortex::getPsrReg();
 }
 
 // CHECK-LABEL: <test_get_psr>:
@@ -82,9 +74,8 @@ extern "C" [[gnu::naked]] void test_get_psr() {
 // CHECK-EMPTY:
 
 // Test getMspReg()
-extern "C" [[gnu::naked]] void test_get_msp() {
-    uint32_t msp = ArmCortex::getMspReg();
-    (void)msp;
+extern "C" [[gnu::naked]] uint32_t test_get_msp() {
+    return ArmCortex::getMspReg();
 }
 
 // CHECK-LABEL: <test_get_msp>:
@@ -104,9 +95,8 @@ extern "C" [[gnu::naked]] void test_set_msp() {
 // CHECK-EMPTY:
 
 // Test getPspReg()
-extern "C" [[gnu::naked]] void test_get_psp() {
-    uint32_t psp = ArmCortex::getPspReg();
-    (void)psp;
+extern "C" [[gnu::naked]] uint32_t test_get_psp() {
+    return ArmCortex::getPspReg();
 }
 
 // CHECK-LABEL: <test_get_psp>:
@@ -124,9 +114,8 @@ extern "C" [[gnu::naked]] void test_set_psp() {
 // CHECK-EMPTY:
 
 // Test getPrimaskReg()
-extern "C" [[gnu::naked]] void test_get_primask() {
-    ArmCortex::PRIMASK primask = ArmCortex::getPrimaskReg();
-    (void)primask;
+extern "C" [[gnu::naked]] ArmCortex::PRIMASK test_get_primask() {
+    return ArmCortex::getPrimaskReg();
 }
 
 // CHECK-LABEL: <test_get_primask>:
@@ -147,9 +136,8 @@ extern "C" [[gnu::naked]] void test_set_primask() {
 // CHECK-EMPTY:
 
 // Test getControlReg()
-extern "C" [[gnu::naked]] void test_get_control() {
-    ArmCortex::CONTROL control = ArmCortex::getControlReg();
-    (void)control;
+extern "C" [[gnu::naked]] ArmCortex::CONTROL test_get_control() {
+    return ArmCortex::getControlReg();
 }
 
 // CHECK-LABEL: <test_get_control>:
@@ -174,9 +162,8 @@ extern "C" [[gnu::naked]] void test_set_control() {
 // ============================================================================
 
 // Test getFaultmaskReg()
-extern "C" [[gnu::naked]] void test_get_faultmask() {
-    ArmCortex::FAULTMASK faultmask = ArmCortex::getFaultmaskReg();
-    (void)faultmask;
+extern "C" [[gnu::naked]] ArmCortex::FAULTMASK test_get_faultmask() {
+    return ArmCortex::getFaultmaskReg();
 }
 
 // CHECK-LABEL: <test_get_faultmask>:
@@ -197,9 +184,8 @@ extern "C" [[gnu::naked]] void test_set_faultmask() {
 // CHECK-EMPTY:
 
 // Test getBasepriReg()
-extern "C" [[gnu::naked]] void test_get_basepri() {
-    ArmCortex::BASEPRI basepri = ArmCortex::getBasepriReg();
-    (void)basepri;
+extern "C" [[gnu::naked]] ArmCortex::BASEPRI test_get_basepri() {
+    return ArmCortex::getBasepriReg();
 }
 
 // CHECK-LABEL: <test_get_basepri>:

--- a/tests/m3/test_special_regs.cpp
+++ b/tests/m3/test_special_regs.cpp
@@ -215,5 +215,5 @@ extern "C" [[gnu::naked]] void test_set_basepri_max() {
 // CHECK-LABEL: <test_set_basepri_max>:
 // CHECK-NEXT: movs r3, #128
 // CHECK-NEXT: msr BASEPRI_MAX, r3
-// MAXSPEED-CHECK-NEXT: nop
+// CHECK-NEXT: nop
 // CHECK-EMPTY:

--- a/tests/m3/test_special_regs.cpp
+++ b/tests/m3/test_special_regs.cpp
@@ -6,8 +6,7 @@ extern "C" [[gnu::naked]] uint32_t test_get_lr() {
 }
 
 // CHECK-LABEL: <test_get_lr>:
-// CHECK-NEXT: mov r3, lr
-// MAXSPEED-CHECK-NEXT: nop
+// CHECK-NEXT: mov r0, lr
 // CHECK-EMPTY:
 
 // Test getApsrReg()
@@ -16,7 +15,7 @@ extern "C" [[gnu::naked]] ArmCortex::PSR test_get_apsr() {
 }
 
 // CHECK-LABEL: <test_get_apsr>:
-// CHECK-NEXT: mrs r3, CPSR
+// CHECK-NEXT: mrs r0, CPSR
 // CHECK-EMPTY:
 
 // Test getIpsrReg()
@@ -25,7 +24,7 @@ extern "C" [[gnu::naked]] ArmCortex::PSR test_get_ipsr() {
 }
 
 // CHECK-LABEL: <test_get_ipsr>:
-// CHECK-NEXT: mrs r3, IPSR
+// CHECK-NEXT: mrs r0, IPSR
 // CHECK-EMPTY:
 
 // Test getEpsrReg()
@@ -34,7 +33,7 @@ extern "C" [[gnu::naked]] ArmCortex::PSR test_get_epsr() {
 }
 
 // CHECK-LABEL: <test_get_epsr>:
-// CHECK-NEXT: mrs r3, EPSR
+// CHECK-NEXT: mrs r0, EPSR
 // CHECK-EMPTY:
 
 // Test getIepsrReg()
@@ -43,7 +42,7 @@ extern "C" [[gnu::naked]] ArmCortex::PSR test_get_iepsr() {
 }
 
 // CHECK-LABEL: <test_get_iepsr>:
-// CHECK-NEXT: mrs r3, IEPSR
+// CHECK-NEXT: mrs r0, IEPSR
 // CHECK-EMPTY:
 
 // Test getIapsrReg()
@@ -52,7 +51,7 @@ extern "C" [[gnu::naked]] ArmCortex::PSR test_get_iapsr() {
 }
 
 // CHECK-LABEL: <test_get_iapsr>:
-// CHECK-NEXT: mrs r3, IAPSR
+// CHECK-NEXT: mrs r0, IAPSR
 // CHECK-EMPTY:
 
 // Test getEapsrReg()
@@ -61,7 +60,7 @@ extern "C" [[gnu::naked]] ArmCortex::PSR test_get_eapsr() {
 }
 
 // CHECK-LABEL: <test_get_eapsr>:
-// CHECK-NEXT: mrs r3, EAPSR
+// CHECK-NEXT: mrs r0, EAPSR
 // CHECK-EMPTY:
 
 // Test getPsrReg()
@@ -70,7 +69,7 @@ extern "C" [[gnu::naked]] ArmCortex::PSR test_get_psr() {
 }
 
 // CHECK-LABEL: <test_get_psr>:
-// CHECK-NEXT: mrs r3, PSR
+// CHECK-NEXT: mrs r0, PSR
 // CHECK-EMPTY:
 
 // Test getMspReg()
@@ -79,7 +78,7 @@ extern "C" [[gnu::naked]] uint32_t test_get_msp() {
 }
 
 // CHECK-LABEL: <test_get_msp>:
-// CHECK-NEXT: mrs r3, MSP
+// CHECK-NEXT: mrs r0, MSP
 // CHECK-EMPTY:
 
 // Test setMspReg()
@@ -90,7 +89,6 @@ extern "C" [[gnu::naked]] void test_set_msp() {
 // CHECK-LABEL: <test_set_msp>:
 // CHECK-NEXT: ldr r3, [pc, #4]
 // CHECK-NEXT: msr MSP, r3
-// MAXSPEED-CHECK-NEXT: nop
 // CHECK-NEXT: .word 0x20001000
 // CHECK-EMPTY:
 
@@ -100,7 +98,7 @@ extern "C" [[gnu::naked]] uint32_t test_get_psp() {
 }
 
 // CHECK-LABEL: <test_get_psp>:
-// CHECK-NEXT: mrs r3, PSP
+// CHECK-NEXT: mrs r0, PSP
 // CHECK-EMPTY:
 
 // Test setPspReg()
@@ -119,7 +117,7 @@ extern "C" [[gnu::naked]] ArmCortex::PRIMASK test_get_primask() {
 }
 
 // CHECK-LABEL: <test_get_primask>:
-// CHECK-NEXT: mrs r3, PRIMASK
+// CHECK-NEXT: mrs r0, PRIMASK
 // CHECK-EMPTY:
 
 // Test setPrimaskReg()
@@ -132,7 +130,6 @@ extern "C" [[gnu::naked]] void test_set_primask() {
 // CHECK-LABEL: <test_set_primask>:
 // CHECK-NEXT: movs r3, #1
 // CHECK-NEXT: msr PRIMASK, r3
-// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test getControlReg()
@@ -141,7 +138,7 @@ extern "C" [[gnu::naked]] ArmCortex::CONTROL test_get_control() {
 }
 
 // CHECK-LABEL: <test_get_control>:
-// CHECK-NEXT: mrs r3, CONTROL
+// CHECK-NEXT: mrs r0, CONTROL
 // CHECK-EMPTY:
 
 // Test setControlReg()
@@ -154,7 +151,6 @@ extern "C" [[gnu::naked]] void test_set_control() {
 // CHECK-LABEL: <test_set_control>:
 // CHECK-NEXT: movs r3, #2
 // CHECK-NEXT: msr CONTROL, r3
-// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // ============================================================================
@@ -167,7 +163,7 @@ extern "C" [[gnu::naked]] ArmCortex::FAULTMASK test_get_faultmask() {
 }
 
 // CHECK-LABEL: <test_get_faultmask>:
-// CHECK-NEXT: mrs r3, FAULTMASK
+// CHECK-NEXT: mrs r0, FAULTMASK
 // CHECK-EMPTY:
 
 // Test setFaultmaskReg()
@@ -180,7 +176,6 @@ extern "C" [[gnu::naked]] void test_set_faultmask() {
 // CHECK-LABEL: <test_set_faultmask>:
 // CHECK-NEXT: movs r3, #1
 // CHECK-NEXT: msr FAULTMASK, r3
-// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test getBasepriReg()
@@ -189,7 +184,7 @@ extern "C" [[gnu::naked]] ArmCortex::BASEPRI test_get_basepri() {
 }
 
 // CHECK-LABEL: <test_get_basepri>:
-// CHECK-NEXT: mrs r3, BASEPRI
+// CHECK-NEXT: mrs r0, BASEPRI
 // CHECK-EMPTY:
 
 // Test setBasepriReg()
@@ -202,7 +197,6 @@ extern "C" [[gnu::naked]] void test_set_basepri() {
 // CHECK-LABEL: <test_set_basepri>:
 // CHECK-NEXT: movs r3, #64
 // CHECK-NEXT: msr BASEPRI, r3
-// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test setBasepriMaxReg()

--- a/tests/m3/test_special_regs.cpp
+++ b/tests/m3/test_special_regs.cpp
@@ -7,6 +7,7 @@ extern "C" [[gnu::naked]] uint32_t test_get_lr() {
 
 // CHECK-LABEL: <test_get_lr>:
 // CHECK-NEXT: mov r0, lr
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test getApsrReg()
@@ -89,6 +90,7 @@ extern "C" [[gnu::naked]] void test_set_msp() {
 // CHECK-LABEL: <test_set_msp>:
 // CHECK-NEXT: ldr r3, [pc, #4]
 // CHECK-NEXT: msr MSP, r3
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-NEXT: .word 0x20001000
 // CHECK-EMPTY:
 
@@ -130,6 +132,7 @@ extern "C" [[gnu::naked]] void test_set_primask() {
 // CHECK-LABEL: <test_set_primask>:
 // CHECK-NEXT: movs r3, #1
 // CHECK-NEXT: msr PRIMASK, r3
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test getControlReg()
@@ -151,6 +154,7 @@ extern "C" [[gnu::naked]] void test_set_control() {
 // CHECK-LABEL: <test_set_control>:
 // CHECK-NEXT: movs r3, #2
 // CHECK-NEXT: msr CONTROL, r3
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // ============================================================================
@@ -176,6 +180,7 @@ extern "C" [[gnu::naked]] void test_set_faultmask() {
 // CHECK-LABEL: <test_set_faultmask>:
 // CHECK-NEXT: movs r3, #1
 // CHECK-NEXT: msr FAULTMASK, r3
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test getBasepriReg()
@@ -197,6 +202,7 @@ extern "C" [[gnu::naked]] void test_set_basepri() {
 // CHECK-LABEL: <test_set_basepri>:
 // CHECK-NEXT: movs r3, #64
 // CHECK-NEXT: msr BASEPRI, r3
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test setBasepriMaxReg()
@@ -209,5 +215,5 @@ extern "C" [[gnu::naked]] void test_set_basepri_max() {
 // CHECK-LABEL: <test_set_basepri_max>:
 // CHECK-NEXT: movs r3, #128
 // CHECK-NEXT: msr BASEPRI_MAX, r3
-// CHECK-NEXT: nop
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:

--- a/tests/m3/test_systick.cpp
+++ b/tests/m3/test_systick.cpp
@@ -8,6 +8,7 @@ extern "C" [[gnu::naked]] auto test_read_ctrl() {
 // CHECK-LABEL: <test_read_ctrl>:
 // CHECK-NEXT: mov.w r3, #3758153728
 // CHECK-NEXT: ldr r0, [r3, #16]
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test writing CTRL register
@@ -33,6 +34,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_load() {
 // CHECK-LABEL: <test_read_load>:
 // CHECK-NEXT: mov.w r3, #3758153728
 // CHECK-NEXT: ldr r0, [r3, #20]
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test writing LOAD register
@@ -44,6 +46,7 @@ extern "C" [[gnu::naked]] void test_write_load() {
 // CHECK-NEXT: mov.w r3, #3758153728
 // CHECK-NEXT: mvn.w r2, #4278190080
 // CHECK-NEXT: str r2, [r3, #20]
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test reading VAL register
@@ -54,6 +57,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_val() {
 // CHECK-LABEL: <test_read_val>:
 // CHECK-NEXT: mov.w r3, #3758153728
 // CHECK-NEXT: ldr r0, [r3, #24]
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test writing VAL register (clears counter)
@@ -75,6 +79,7 @@ extern "C" [[gnu::naked]] auto test_read_calib() {
 // CHECK-LABEL: <test_read_calib>:
 // CHECK-NEXT: mov.w r3, #3758153728
 // CHECK-NEXT: ldr r0, [r3, #28]
+// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test enabling SysTick with CPU clock

--- a/tests/m3/test_systick.cpp
+++ b/tests/m3/test_systick.cpp
@@ -1,9 +1,8 @@
 #include "armcortex/m3/systick.hpp"
 
 // Test reading CTRL register
-extern "C" [[gnu::naked]] void test_read_ctrl() {
-    auto ctrl = ArmCortex::SysTick::CTRL(ArmCortex::SYS_TICK->CTRL);
-    (void)ctrl;
+extern "C" [[gnu::naked]] auto test_read_ctrl() {
+    return ArmCortex::SysTick::CTRL(ArmCortex::SYS_TICK->CTRL);
 }
 
 // CHECK-LABEL: <test_read_ctrl>:
@@ -28,9 +27,8 @@ extern "C" [[gnu::naked]] void test_write_ctrl() {
 // CHECK-EMPTY:
 
 // Test reading LOAD register
-extern "C" [[gnu::naked]] void test_read_load() {
-    uint32_t load = ArmCortex::SYS_TICK->LOAD;
-    (void)load;
+extern "C" [[gnu::naked]] uint32_t test_read_load() {
+    return ArmCortex::SYS_TICK->LOAD;
 }
 
 // CHECK-LABEL: <test_read_load>:
@@ -52,9 +50,8 @@ extern "C" [[gnu::naked]] void test_write_load() {
 // CHECK-EMPTY:
 
 // Test reading VAL register
-extern "C" [[gnu::naked]] void test_read_val() {
-    uint32_t val = ArmCortex::SYS_TICK->VAL;
-    (void)val;
+extern "C" [[gnu::naked]] uint32_t test_read_val() {
+    return ArmCortex::SYS_TICK->VAL;
 }
 
 // CHECK-LABEL: <test_read_val>:
@@ -75,9 +72,8 @@ extern "C" [[gnu::naked]] void test_write_val() {
 // CHECK-EMPTY:
 
 // Test reading CALIB register
-extern "C" [[gnu::naked]] void test_read_calib() {
-    auto calib = ArmCortex::SysTick::CALIB(ArmCortex::SYS_TICK->CALIB);
-    (void)calib;
+extern "C" [[gnu::naked]] auto test_read_calib() {
+    return ArmCortex::SysTick::CALIB(ArmCortex::SYS_TICK->CALIB);
 }
 
 // CHECK-LABEL: <test_read_calib>:

--- a/tests/m3/test_systick.cpp
+++ b/tests/m3/test_systick.cpp
@@ -7,8 +7,7 @@ extern "C" [[gnu::naked]] auto test_read_ctrl() {
 
 // CHECK-LABEL: <test_read_ctrl>:
 // CHECK-NEXT: mov.w r3, #3758153728
-// CHECK-NEXT: ldr r3, [r3, #16]
-// MAXSPEED-CHECK-NEXT: nop
+// CHECK-NEXT: ldr r0, [r3, #16]
 // CHECK-EMPTY:
 
 // Test writing CTRL register
@@ -33,8 +32,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_load() {
 
 // CHECK-LABEL: <test_read_load>:
 // CHECK-NEXT: mov.w r3, #3758153728
-// CHECK-NEXT: ldr r3, [r3, #20]
-// MAXSPEED-CHECK-NEXT: nop
+// CHECK-NEXT: ldr r0, [r3, #20]
 // CHECK-EMPTY:
 
 // Test writing LOAD register
@@ -46,7 +44,6 @@ extern "C" [[gnu::naked]] void test_write_load() {
 // CHECK-NEXT: mov.w r3, #3758153728
 // CHECK-NEXT: mvn.w r2, #4278190080
 // CHECK-NEXT: str r2, [r3, #20]
-// MAXSPEED-CHECK-NEXT: nop
 // CHECK-EMPTY:
 
 // Test reading VAL register
@@ -56,8 +53,7 @@ extern "C" [[gnu::naked]] uint32_t test_read_val() {
 
 // CHECK-LABEL: <test_read_val>:
 // CHECK-NEXT: mov.w r3, #3758153728
-// CHECK-NEXT: ldr r3, [r3, #24]
-// MAXSPEED-CHECK-NEXT: nop
+// CHECK-NEXT: ldr r0, [r3, #24]
 // CHECK-EMPTY:
 
 // Test writing VAL register (clears counter)
@@ -78,8 +74,7 @@ extern "C" [[gnu::naked]] auto test_read_calib() {
 
 // CHECK-LABEL: <test_read_calib>:
 // CHECK-NEXT: mov.w r3, #3758153728
-// CHECK-NEXT: ldr r3, [r3, #28]
-// MAXSPEED-CHECK-NEXT: nop
+// CHECK-NEXT: ldr r0, [r3, #28]
 // CHECK-EMPTY:
 
 // Test enabling SysTick with CPU clock


### PR DESCRIPTION
## Summary

This PR fixes all 34 instances of the `(void)` cast pattern in M0+ tests that allowed the compiler to optimize away register reads.

## Problem

In `[[gnu::naked]]` functions, when a value is read and then immediately discarded with `(void)`, the compiler can optimize away the entire memory read operation since it determines the result is unused.

**Before (broken):**
```cpp
extern "C" [[gnu::naked]] void test_read_type() {
    auto type = ArmCortex::Mpu::TYPE(ArmCortex::MPU->TYPE);
    (void)type;  // Compiler may skip the read entirely!
}
```

## Solution

By returning the value instead, we force the compiler to materialize the result in `r0` per ARM calling convention, ensuring the register read actually happens.

**After (correct):**
```cpp
extern "C" [[gnu::naked]] auto test_read_type() {
    return ArmCortex::Mpu::TYPE(ArmCortex::MPU->TYPE);
}
```

## Changes

| File | Instances Fixed |
|------|-----------------|
| `test_mpu.cpp` | 5 |
| `test_nvic.cpp` | 3 |
| `test_scb.cpp` | 9 |
| `test_special_regs.cpp` | 12 |
| `test_systick.cpp` | 5 |
| **Total** | **34** |

## CHECK Pattern Updates

All CHECK patterns have been updated to expect the result in `r0` instead of `r3`:
```diff
-// CHECK-NEXT: ldr r3, [r3, #0]
+// CHECK-NEXT: ldr r0, [r3, #0]
```