### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci_pr_validation.yml
+++ b/.github/workflows/ci_pr_validation.yml
@@ -1,5 +1,8 @@
 name: CI - PR Validation
 
+permissions:
+  contents: read
+
 on:
     pull_request:
         branches: ["**"] # Run PR validation on any branch.

--- a/.github/workflows/ci_pr_validation.yml
+++ b/.github/workflows/ci_pr_validation.yml
@@ -1,7 +1,7 @@
 name: CI - PR Validation
 
 permissions:
-  contents: read
+    contents: read
 
 on:
     pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/MatejGomboc/ARMCortexM-CppLib/security/code-scanning/1](https://github.com/MatejGomboc/ARMCortexM-CppLib/security/code-scanning/1)

To fix this problem, an explicit `permissions` block should be added to the workflow scope (or individually to jobs if some require a different set of permissions). The minimal and safest default, given the workflow's steps, would be to allow read-only access to repository contents. This is done by adding:
```yaml
permissions:
  contents: read
```
at the root level, between the `name` and the `on:` keys (so it applies to all jobs). No changes to imports or additional methods are needed in a YAML workflow file, and no jobs appear to require write-level permissions based on the shown steps. If a future step or job does require broader permissions, the scope should be expanded appropriately and explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
