### PR TITLE
Run Dependabot weekly at 00:00 on Saturdays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: weekly
+      day: saturday
       time: "00:00"
+      timezone: "Europe/Ljubljana"


### PR DESCRIPTION
Throttles Dependabot to one weekly run at the midnight between Friday and Saturday (00:00 Europe/Ljubljana) to conserve GitHub Actions minutes.

đź¤– Generated with [Claude Code](https://claude.com/claude-code)