### PR TITLE
wip: preserve abandoned constexpr register-pointer experiment (do not merge)

### DIFF
--- a/asm_tests/utils_tests/CMakeLists.txt
+++ b/asm_tests/utils_tests/CMakeLists.txt
@@ -1,1 +1,3 @@
 add_asm_test(test_const_int_ceil_div)
+#add_asm_test(test_runtime_int_ceil_div)
+#add_asm_test(test_is_bit_set)

--- a/asm_tests/utils_tests/test_is_bit_set.cpp
+++ b/asm_tests/utils_tests/test_is_bit_set.cpp
@@ -1,0 +1,10 @@
+#include "utils.hpp"
+
+extern "C" bool test_is_bit_set(unsigned long value, uint8_t bit) {
+    return Utils::isBitSet(value, bit);
+}
+
+// CHECK-LABEL: <test_is_bit_set>:
+// CHECK: movs r0, #4
+// CHECK: movs r1, #0
+// CHECK-NEXT: bx lr

--- a/asm_tests/utils_tests/test_runtime_int_ceil_div.cpp
+++ b/asm_tests/utils_tests/test_runtime_int_ceil_div.cpp
@@ -1,0 +1,7 @@
+#include "utils.hpp"
+
+extern "C" uint32_t test_runtime_ceil_div1(uint32_t a, uint32_t b) {
+    return Utils::intCeilDiv(a, b);
+}
+
+// CHECK-LABEL: test_runtime_ceil_div1:

--- a/cortexm0/nvic.hpp
+++ b/cortexm0/nvic.hpp
@@ -21,7 +21,7 @@
 #include <cstdint>
 
 namespace CortexM0::Nvic {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000E100);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000E100);
 
     struct Registers
     {
@@ -37,9 +37,8 @@ namespace CortexM0::Nvic {
         volatile uint8_t ipr[32]; //!< sets priorities of interrupts
     };
 
-    static inline volatile Registers* registers()
-    {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+    static constexpr volatile Registers* NVIC{
+        reinterpret_cast<volatile Registers*>(BASE_ADDR);
     }
 
     static inline bool isIrqEnabled(uint8_t irq_number)

--- a/cortexm0/scb.hpp
+++ b/cortexm0/scb.hpp
@@ -20,7 +20,7 @@
 #include <cstdint>
 
 namespace CortexM0::Scb {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000ED00);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000ED00);
 
     //! is a read-only register and contains the processor part number, version, and implementation information
     union Cpuid {
@@ -188,7 +188,7 @@ namespace CortexM0::Scb {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 
     [[noreturn]] static inline void systemReset()

--- a/cortexm0/systick.hpp
+++ b/cortexm0/systick.hpp
@@ -19,7 +19,7 @@
 #include <cstdint>
 
 namespace CortexM0::SysTick {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000E010);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000E010);
 
     union CtrlStatus {
         //! timer clock source
@@ -79,6 +79,6 @@ namespace CortexM0::SysTick {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 }

--- a/cortexm0plus/mpu.hpp
+++ b/cortexm0plus/mpu.hpp
@@ -19,7 +19,7 @@
 #include <cstdint>
 
 namespace CortexM0Plus::Mpu {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000ED90);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000ED90);
 
     union Type {
         struct Bits {
@@ -99,7 +99,7 @@ namespace CortexM0Plus::Mpu {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 
     static inline void configureRegion(uint32_t idx, uint32_t base_addr, const RegionAttributes& attributes)

--- a/cortexm0plus/nvic.hpp
+++ b/cortexm0plus/nvic.hpp
@@ -21,7 +21,7 @@
 #include <cstdint>
 
 namespace CortexM0Plus::Nvic {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000E100);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000E100);
 
     struct Registers
     {
@@ -39,7 +39,7 @@ namespace CortexM0Plus::Nvic {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 
     static inline bool isIrqEnabled(uint8_t irq_number)

--- a/cortexm0plus/scb.hpp
+++ b/cortexm0plus/scb.hpp
@@ -20,7 +20,7 @@
 #include <cstdint>
 
 namespace CortexM0Plus::Scb {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000ED00);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000ED00);
 
     //! is a read-only register and contains the processor part number, version, and implementation information
     union Cpuid {
@@ -188,7 +188,7 @@ namespace CortexM0Plus::Scb {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 
     [[noreturn]] static inline void systemReset()

--- a/cortexm0plus/systick.hpp
+++ b/cortexm0plus/systick.hpp
@@ -19,7 +19,7 @@
 #include <cstdint>
 
 namespace CortexM0Plus::SysTick {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000E010);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000E010);
 
     union CtrlStatus {
         //! timer clock source
@@ -79,6 +79,6 @@ namespace CortexM0Plus::SysTick {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 }

--- a/cortexm1/nvic.hpp
+++ b/cortexm1/nvic.hpp
@@ -20,7 +20,7 @@
 #include <cstdint>
 
 namespace CortexM1::Nvic {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000E100);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000E100);
 
     struct Registers
     {
@@ -38,7 +38,7 @@ namespace CortexM1::Nvic {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 
     static inline bool isIrqEnabled(uint8_t irq_number)

--- a/cortexm1/scb.hpp
+++ b/cortexm1/scb.hpp
@@ -19,7 +19,7 @@
 #include <cstdint>
 
 namespace CortexM1::Scb {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000ED00);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000ED00);
 
     //! is a read-only register and contains the processor part number, version, and implementation information
     union Cpuid {
@@ -187,7 +187,7 @@ namespace CortexM1::Scb {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 
     [[noreturn]] static inline void systemReset()

--- a/cortexm1/systick.hpp
+++ b/cortexm1/systick.hpp
@@ -19,7 +19,7 @@
 #include <cstdint>
 
 namespace CortexM1::SysTick {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000E010);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000E010);
 
     union CtrlStatus {
         //! timer clock source
@@ -79,6 +79,6 @@ namespace CortexM1::SysTick {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 }

--- a/cortexm3/mpu.hpp
+++ b/cortexm3/mpu.hpp
@@ -19,7 +19,7 @@
 #include <cstdint>
 
 namespace CortexM3::Mpu {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000ED90);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000ED90);
 
     union Type {
         struct Bits {
@@ -106,7 +106,7 @@ namespace CortexM3::Mpu {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 
     static inline void configureRegion(uint32_t idx, uint32_t base_addr, const RegionAttributes& attributes)

--- a/cortexm3/nvic.hpp
+++ b/cortexm3/nvic.hpp
@@ -20,7 +20,7 @@
 #include <cstdint>
 
 namespace CortexM3::Nvic {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000E100);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000E100);
 
     struct Registers
     {
@@ -41,7 +41,7 @@ namespace CortexM3::Nvic {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 
     static inline bool isIrqEnabled(uint8_t irq_number)

--- a/cortexm3/scb.hpp
+++ b/cortexm3/scb.hpp
@@ -19,7 +19,7 @@
 #include <cstdint>
 
 namespace CortexM3::Scb {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000ED00);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000ED00);
 
     //! is a read-only register and contains the processor part number, version, and implementation information
     union Cpuid {
@@ -314,7 +314,7 @@ namespace CortexM3::Scb {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 
     [[noreturn]] static inline void systemReset()

--- a/cortexm3/systick.hpp
+++ b/cortexm3/systick.hpp
@@ -19,7 +19,7 @@
 #include <cstdint>
 
 namespace CortexM3::SysTick {
-    static uint32_t* const BASE_ADDR = reinterpret_cast<uint32_t*>(0xE000E010);
+    static constexpr uint32_t* BASE_ADDR = static_cast<uint32_t*>(0xE000E010);
 
     union CtrlStatus {
         //! timer clock source
@@ -79,6 +79,6 @@ namespace CortexM3::SysTick {
 
     static inline volatile Registers* registers()
     {
-        return reinterpret_cast<volatile Registers*>(BASE_ADDR);
+        return static_cast<volatile Registers*>(BASE_ADDR);
     }
 }


### PR DESCRIPTION
**Preservation only — do not merge.**

Salvages uncommitted local work found during repository retirement: an abandoned experiment replacing the `registers()` accessor functions with `constexpr` register pointers, plus two FileCheck test stubs (`test_is_bit_set`, `test_runtime_int_ceil_div`) whose CMake registrations were left commented out.

The experiment does not compile as written (integer-to-pointer `static_cast` is invalid, and the `Nvic` brace-initialiser has a syntax error) — it is preserved here for reference before archiving. If the constexpr-register idea or the test stubs are still wanted, port them to the [Embedded Society](https://github.com/embedded-society) per-core repositories instead.

Close without merging once noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
